### PR TITLE
Initialize tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,11 +2,11 @@ organization := "definiti"
 
 name := "scala-model"
 
-version := "0.1.0"
+version := "0.2.0-snapshot"
 
 scalaVersion := "2.12.1"
 
-libraryDependencies += "definiti" %%  "core" % "0.2.0"
+libraryDependencies += "definiti" %%  "core" % "0.2.0-snapshot"
 libraryDependencies += "commons-io" % "commons-io" % "2.5"
 libraryDependencies += "com.typesafe" % "config" % "1.3.1"
 libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.5.0"

--- a/src/main/scala/definiti/scalamodel/ScalaAST.scala
+++ b/src/main/scala/definiti/scalamodel/ScalaAST.scala
@@ -11,12 +11,24 @@ object ScalaAST {
     elements: Seq[PackageElement]
   )
 
+  object Root {
+    def apply(elements: PackageElement*)(implicit dummyImplicit: DummyImplicit): Root = {
+      new Root(elements)
+    }
+  }
+
   sealed trait PackageElement
 
   case class Package(
     name: String,
     elements: Seq[PackageElement]
   ) extends PackageElement
+
+  object Package {
+    def apply(name: String, elements: PackageElement*)(implicit dummyImplicit: DummyImplicit): Package = {
+      new Package(name, elements)
+    }
+  }
 
   case class PackageDeclaration(name: String) extends Statement
 
@@ -35,6 +47,12 @@ object ScalaAST {
     property: Option[String] = None
   ) extends Statement with PackageElement
 
+  object CaseClassDef {
+    def apply(name: String, parameters: Parameter*): CaseClassDef = {
+      new CaseClassDef(name, parameters)
+    }
+  }
+
   sealed trait Statement
 
   sealed trait Expression extends Statement
@@ -52,6 +70,13 @@ object ScalaAST {
   case class IfThenElse(cond: Expression, ifTrue: Expression, ifFalse: Expression) extends If
 
   case class Parameter(name: String, typ: String, defaultValue: Option[Expression] = None, property: Option[String] = None)
+
+  object Parameter {
+    def apply(name: String, typ: String, defaultValue: Expression): Parameter = {
+      new Parameter(name, typ, Some(defaultValue), None)
+    }
+  }
+
   case class Lambda(parameters: Seq[Parameter], body: Expression) extends Expression
 
   case class CallAttribute(target: Expression, name: String) extends Expression with Unambiguous
@@ -98,6 +123,12 @@ object ScalaAST {
     property: Option[String] = None
   ) extends Statement with PackageElement
 
+  object Def1 {
+    def apply(name: String, typ: String, parameters: Seq[Parameter], body: Expression): Def1 = {
+      new Def1(name, typ, Seq.empty, parameters, Some(body), None)
+    }
+  }
+
   case class Def2(
     name: String,
     typ: String,
@@ -142,6 +173,10 @@ object ScalaAST {
   case class ClassDef(name: String, extendz: Option[String], parameters: Seq[Parameter], body: Seq[Statement], property: Option[String], privateConstructor: Boolean) extends Statement
 
   case class ClassVal(name: String, typ: String, body: Seq[Statement], isLazy: Boolean = false, isPrivate: Boolean = false) extends Statement
+
+  object ClassVal {
+    def apply(name: String, typ: String, body: Statement*): ClassVal = new ClassVal(name, typ, body)
+  }
 
   case class TypeDef(name: String, typ: String) extends Statement
 

--- a/src/test/resources/samples/nominal/aliasType.def
+++ b/src/test/resources/samples/nominal/aliasType.def
@@ -1,0 +1,1 @@
+type AliasString = String

--- a/src/test/resources/samples/nominal/definedType.def
+++ b/src/test/resources/samples/nominal/definedType.def
@@ -1,0 +1,3 @@
+type MyType {
+  myAttribute: String
+}

--- a/src/test/resources/samples/nominal/extendedContext.def
+++ b/src/test/resources/samples/nominal/extendedContext.def
@@ -1,0 +1,3 @@
+context stringContext {{{
+  Something here
+}}}

--- a/src/test/resources/samples/nominal/namedFunction.def
+++ b/src/test/resources/samples/nominal/namedFunction.def
@@ -1,0 +1,3 @@
+def alwaysFalse(): Boolean => {
+  false
+}

--- a/src/test/resources/samples/nominal/package.def
+++ b/src/test/resources/samples/nominal/package.def
@@ -1,0 +1,3 @@
+package tst
+
+type AliasString = String

--- a/src/test/resources/samples/nominal/verification.def
+++ b/src/test/resources/samples/nominal/verification.def
@@ -1,0 +1,6 @@
+verification AlwaysTrue {
+  "Never fail"
+  (x: String) => {
+    true
+  }
+}

--- a/src/test/scala/definiti/scalamodel/NominalSpec.scala
+++ b/src/test/scala/definiti/scalamodel/NominalSpec.scala
@@ -1,0 +1,96 @@
+package definiti.scalamodel
+
+import definiti.core.ValidValue
+import definiti.scalamodel.ScalaAST._
+import definiti.scalamodel.helpers.EndToEndSpec
+
+class NominalSpec extends EndToEndSpec {
+  import NominalSpec._
+
+  "The generator" should "generate a valid scala AST for a valid defined type" in {
+    val expected = ValidValue(definedType)
+    val output = processFile("nominal.definedType")
+    output should be(expected)
+  }
+
+  it should "generate a valid scala AST for a valid alias type" in {
+    val expected = ValidValue(aliasType)
+    val output = processFile("nominal.aliasType")
+    output should be(expected)
+  }
+
+  it should "generate a valid scala AST for a valid verification" in {
+    val expected = ValidValue(verification)
+    val output = processFile("nominal.verification")
+    output should be(expected)
+  }
+
+  it should "generate a valid scala AST for a valid named function" in {
+    val expected = ValidValue(namedFunction)
+    val output = processFile("nominal.namedFunction")
+    output should be(expected)
+  }
+
+  it should "generate nothing from an extended context" in {
+    val expected = ValidValue(extendedContext)
+    val output = processFile("nominal.extendedContext")
+    output should be(expected)
+  }
+
+  it should "generate a valid scala AST for a valid alias type in a package" in {
+    val expected = ValidValue(packageAliasType)
+    val output = processFile("nominal.package")
+    output should be(expected)
+  }
+}
+
+
+object NominalSpec {
+  import definiti.scalamodel.helpers.AstHelper._
+
+  val definedType: Root = Root(
+    CaseClassDef("MyType", Parameter("myAttribute", "String")),
+    ObjectDef(
+      name = "MyType",
+      body = Seq(
+        attributeVerification("myAttribute", "String"),
+        typeVerifications("MyType"),
+        allVerifications("MyType", "myAttribute"),
+        applyCheck("MyType", "myAttribute" -> "String")
+      )
+    )
+  )
+
+  val aliasType: Root = Root(
+    ObjectDef(
+      name = "AliasString",
+      body = Seq(
+        typeVerifications("AliasString", "String"),
+        aliasApplyCheck("AliasString", "String")
+      )
+    )
+  )
+
+  val verification: Root = Root(
+    verificationObject("AlwaysTrue", "String", "Never fail", SimpleExpression("true"))
+  )
+
+  val namedFunction: Root = Root(
+    Def1("alwaysFalse", "Boolean", Seq.empty, SimpleExpression("false"))
+  )
+
+  val extendedContext: Root = Root()
+
+  val packageAliasType: Root = Root(
+    Package(
+      "tst",
+      ObjectDef(
+        name = "AliasString",
+        body = Seq(
+          typeVerifications("AliasString", "String"),
+          aliasApplyCheck("AliasString", "String")
+        )
+      )
+    )
+  )
+}

--- a/src/test/scala/definiti/scalamodel/helpers/AstHelper.scala
+++ b/src/test/scala/definiti/scalamodel/helpers/AstHelper.scala
@@ -1,0 +1,104 @@
+package definiti.scalamodel.helpers
+
+import definiti.scalamodel.ScalaAST._
+
+object AstHelper {
+  def attributeVerification(name: String, typ: String): ClassVal = {
+    ClassVal(s"${name}Verification", s"Verification[${typ}]", CallMethod("Verification", "traverse"))
+  }
+
+  def typeVerifications(typ: String): ClassVal = {
+    typeVerifications(typ, typ)
+  }
+
+  def typeVerifications(typ: String, realType: String): ClassVal = {
+    ClassVal(s"${typ}Verifications", s"Verification[${realType}]", CallMethod("Verification", "traverse"))
+  }
+
+  def allVerifications(typ: String, attributes: String*): ClassVal = {
+    ClassVal(
+      name = "allVerifications",
+      typ = s"Verification[${typ}]",
+      body = Seq(
+        CallMethod(
+          target = CallMethod(
+            target = SimpleExpression("Verification"),
+            name = "traverse",
+            arguments = attributes.map { attribute =>
+              CallMethod(
+                target = SimpleExpression(s"${attribute}Verification"),
+                name = "from",
+                arguments = Seq(
+                  Lambda(
+                    parameters = Seq(Parameter("x", typ)),
+                    body = CallAttribute(SimpleExpression("x"), attribute)
+                  )
+                )
+              )
+            }
+          ),
+          name = "andThen",
+          arguments = Seq(SimpleExpression(s"${typ}Verifications"))
+        )
+      )
+    )
+  }
+
+  def applyCheck(typ: String, attributes: (String, String)*): Def1 = {
+    Def1(
+      name = "applyCheck",
+      typ = s"Validation[${typ}]",
+      generics = Seq.empty,
+      parameters = attributes.map(attribute => Parameter(attribute._1, attribute._2)),
+      body = Some(CallMethod(
+        target = SimpleExpression("allVerifications"),
+        name = "verify",
+        arguments = Seq(
+          CallFunction(
+            target = SimpleExpression(typ),
+            arguments = attributes.map(attribute => SimpleExpression(attribute._1))
+          )
+        )
+      )),
+      property = None
+    )
+  }
+
+  def aliasApplyCheck(typ: String, realType: String): Def1 = {
+    Def1(
+      name = "applyCheck",
+      typ = s"Validation[${realType}]",
+      generics = Seq.empty,
+      parameters = Seq(Parameter("input", realType)),
+      body = Some(CallMethod(s"${typ}Verifications", "verify", SimpleExpression("input"))),
+      None
+    )
+  }
+
+  def verificationObject(name: String, typ: String, message: String, body: Expression): ObjectDef = {
+    ObjectDef(
+      name = name,
+      body = Seq(
+        Def1(
+          name = "apply",
+          typ = s"Verification[${typ}]",
+          generics = Seq.empty,
+          parameters = Seq(Parameter("message", typ, StringExpression(message))),
+          body = Some(CallFunction(
+            target = CallFunction(
+              target = "Verification",
+              arguments = SimpleExpression("message")
+            ),
+            arguments = Seq(
+              Lambda(
+                parameters = Seq(Parameter("x", typ)),
+                body = body
+              )
+            )
+          )),
+          None
+        )
+      )
+    )
+  }
+}

--- a/src/test/scala/definiti/scalamodel/helpers/ConfigurationMock.scala
+++ b/src/test/scala/definiti/scalamodel/helpers/ConfigurationMock.scala
@@ -1,0 +1,14 @@
+package definiti.scalamodel.helpers
+
+import java.nio.file.{Path, Paths}
+
+import definiti.core._
+
+case class ConfigurationMock(
+  source: Path = Paths.get(""),
+  apiSource: Path = Paths.get(""),
+  parsers: Seq[ParserPlugin] = Seq.empty,
+  validators: Seq[ValidatorPlugin] = Seq.empty,
+  generators: Seq[GeneratorPlugin] = Seq.empty,
+  contexts: Seq[ContextPlugin[_]] = Seq.empty
+) extends Configuration

--- a/src/test/scala/definiti/scalamodel/helpers/EndToEndSpec.scala
+++ b/src/test/scala/definiti/scalamodel/helpers/EndToEndSpec.scala
@@ -1,0 +1,43 @@
+package definiti.scalamodel.helpers
+
+import java.nio.file.Paths
+
+import definiti.core.{Configuration => CoreConfiguration, _}
+import definiti.scalamodel.builder.ScalaModelBuilder
+import definiti.scalamodel.{Configuration, ScalaAST}
+import org.scalatest.{FlatSpec, Matchers}
+
+trait EndToEndSpec extends FlatSpec with Matchers {
+  def processDirectory(sample: String): Validated[ScalaAST.Root] = {
+    process(configurationDirectory(sample))
+  }
+
+  def configurationDirectory(sample: String): CoreConfiguration = {
+    ConfigurationMock(
+      source = Paths.get(s"src/test/resources/samples/${sample.replaceAll("\\.", "/")}"),
+      apiSource = Paths.get(s"src/main/resources/api"),
+      contexts = Seq()
+    )
+  }
+
+  def processFile(sample: String): Validated[ScalaAST.Root] = {
+    process(configurationFile(sample))
+  }
+
+  def configurationFile(sample: String): CoreConfiguration = {
+    ConfigurationMock(
+      source = Paths.get(s"src/test/resources/samples/${sample.replaceAll("\\.", "/")}.def"),
+      apiSource = Paths.get(s"src/main/resources/api"),
+      contexts = Seq()
+    )
+  }
+
+  private def process(configuration: CoreConfiguration): Validated[ScalaAST.Root] = {
+    val project = new Project(configuration)
+    project.generateStructureWithLibrary()
+      .map { case (ast, library) =>
+        val builder = new ScalaModelBuilder(new Configuration(), library)
+        builder.build(ast)
+      }
+  }
+}


### PR DESCRIPTION
Until now, there was no automatic tests in the project.
As for the core project, we also initialize travis integration.

This commit do the following:

* Update `build.sbt` to depends to last version of core project and set version as snapshot
* Copy nominal test files from core project
* Generate a test for each nominal test
* Create `EndToEndSpec` and `ConfigurationMock` to simplify test writing
* Create `AstHelper` to simplify AST test writing