### PR TITLE
Enable JSON support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: scala
+scala:
+   - 2.12.1

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -10,8 +10,8 @@ definiti {
     destination = "tmp/target"
 
     json {
-      # spray, none
-      format = "spray"
+      # play, spray, none
+      format = "play"
 
       # flat, none
       validation = "flat"

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -8,5 +8,13 @@ definiti {
 
   scalamodel {
     destination = "tmp/target"
+
+    json {
+      # spray, none
+      format = "spray"
+
+      # flat, none
+      validation = "flat"
+    }
   }
 }

--- a/src/main/resources/native/Verification.scala
+++ b/src/main/resources/native/Verification.scala
@@ -80,7 +80,7 @@ final class ValueVerification[A](check: A => Boolean, message: String) extends V
   override def withMessage(message: String) = new ValueVerification(check, message)
 }
 
-final class ListVerification[A](verification: Verification[A]) extends Verification[List[A]] {
+final class ListVerification[A](verification: Verification[A] = Verification[A]()) extends Verification[List[A]] {
   override def verify[B <: List[A]](value: B) = {
     val validations = value.map(verification.verify)
     if (validations.forall(_.isValid)) {
@@ -95,7 +95,7 @@ final class ListVerification[A](verification: Verification[A]) extends Verificat
   }
 }
 
-final class OptionVerification[A](verification: Verification[A]) extends Verification[Option[A]] {
+final class OptionVerification[A](verification: Verification[A] = Verification[A]()) extends Verification[Option[A]] {
   override def verify[B <: Option[A]](value: B) = {
     value
       .map {

--- a/src/main/resources/native/json/JsonPlaySupport.scala
+++ b/src/main/resources/native/json/JsonPlaySupport.scala
@@ -1,0 +1,38 @@
+package definiti.native
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+import play.api.libs.json._
+
+object JsonPlaySupport {
+  private val datetimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+
+  implicit lazy val dateFormat: Format[LocalDateTime] = Format(dateReads, dateWrites)
+
+  private lazy val dateReads: Reads[LocalDateTime] = Reads { jsValue =>
+    jsValue.validate[String] flatMap { jsString =>
+      try {
+        JsSuccess(LocalDateTime.parse(jsString, datetimeFormatter))
+      } catch {
+        case _: Throwable => JsError(Seq(JsPath() -> Seq(JsonValidationError(s"Expected ISO date, got: $jsString"))))
+      }
+    }
+  }
+
+  private lazy val dateWrites: Writes[LocalDateTime] = Writes[LocalDateTime] {
+    date => JsString(date.format(datetimeFormatter))
+  }
+
+  def formatWithValidation[A](defaultFormat: OFormat[A], verification: Verification[A]): OFormat[A] = {
+    val reads: Reads[A] = Reads { json =>
+      defaultFormat.reads(json).flatMap { value =>
+        verification.verify(value) match {
+          case Valid(value) => JsSuccess(value)
+          case Invalid(errors) => JsError(Seq(JsPath() -> Seq(JsonValidationError(errors))))
+        }
+      }
+    }
+    OFormat(reads, defaultFormat)
+  }
+}

--- a/src/main/resources/native/json/JsonSpraySupport.scala
+++ b/src/main/resources/native/json/JsonSpraySupport.scala
@@ -1,0 +1,53 @@
+package definiti.native
+
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+import my.person.Person
+import my.person.Person.allVerifications
+import spray.json.{DefaultJsonProtocol, JsString, JsValue, JsonFormat, RootJsonFormat, deserializationError}
+
+object JsonSpraySupport extends DefaultJsonProtocol {
+  private val datetimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+
+  implicit val dateTimeFormat: JsonFormat[LocalDateTime] = new JsonFormat[LocalDateTime] {
+    override def write(obj: LocalDateTime): JsValue = JsString(obj.format(datetimeFormatter))
+
+    override def read(json: JsValue): LocalDateTime = json match {
+      case JsString(jsString) =>
+        try {
+          LocalDateTime.parse(jsString, datetimeFormatter)
+        } catch {
+          case _: Throwable => deserializationError(s"Expected ISO date, got: $jsString")
+        }
+      case x =>
+        deserializationError(s"String expected, got: $x")
+    }
+  }
+
+  def enumFormat[A <: Enumeration, B](enum: A, enumWithName: String => B): RootJsonFormat[B] = new RootJsonFormat[B] {
+    override def write(obj: B): JsValue = JsString(obj.toString)
+
+    override def read(json: JsValue): B = json match {
+      case JsString(string) =>
+        try {
+          enumWithName(string)
+        } catch {
+          case _: Throwable => deserializationError(s"One of ${enum.values.mkString("('", "', '", "')")} expected, got: $string")
+        }
+      case x => deserializationError(s"String expected, got: $x")
+    }
+  }
+
+  def formatWithValidation[A](defaultFormat: RootJsonFormat[A], verification: Verification[A]): RootJsonFormat[A] = {
+    new RootJsonFormat[A] {
+      def write(obj: A): JsValue = defaultFormat.write(obj)
+      def read(json: JsValue): A = {
+        verification.verify(defaultFormat.read(json)) match {
+          case Valid(value) => value
+          case Invalid(errors) => deserializationError(errors.mkString("\n"))
+        }
+      }
+    }
+  }
+}

--- a/src/main/scala/definiti/scalamodel/Configuration.scala
+++ b/src/main/scala/definiti/scalamodel/Configuration.scala
@@ -5,7 +5,31 @@ import java.nio.file.{Path, Paths}
 import com.typesafe.config.{Config, ConfigFactory}
 import com.typesafe.scalalogging.Logger
 
-private[scalamodel] class Configuration(config: Config) {
+private[scalamodel] trait Configuration {
+  def destination: Path
+
+  def json: JsonConfiguration
+}
+
+private[scalamodel] case class JsonConfiguration(format: JsonFormat.Value, validation: JsonValidation.Value)
+
+private[scalamodel] object JsonFormat extends Enumeration {
+  val spray, none = Value
+
+  def fromString(value: String): Option[JsonFormat.Value] = {
+    values.find(_.toString == value)
+  }
+}
+
+private[scalamodel] object JsonValidation extends Enumeration {
+  val flat, none = Value
+
+  def fromString(value: String): Option[JsonValidation.Value] = {
+    values.find(_.toString == value)
+  }
+}
+
+private[scalamodel] class FileConfiguration(config: Config) extends Configuration {
   private val logger = Logger(getClass)
 
   def this() {
@@ -16,6 +40,11 @@ private[scalamodel] class Configuration(config: Config) {
     "definiti.scalamodel.destination",
     "definiti.build.destination"
   ).getOrElse(Paths.get("target", "scalamodel"))
+
+  lazy val json: JsonConfiguration = JsonConfiguration(
+    format = getStringOpt("definiti.scalamodel.json.format").flatMap(JsonFormat.fromString).getOrElse(JsonFormat.none),
+    validation = getStringOpt("definiti.scalamodel.json.validation").flatMap(JsonValidation.fromString).getOrElse(JsonValidation.none)
+  )
 
   private def getFirstDefinedPath(keys: String*): Option[Path] = {
     keys
@@ -30,6 +59,14 @@ private[scalamodel] class Configuration(config: Config) {
       val rawPath = config.getString(configurationPath)
       val path = Paths.get(rawPath)
       Some(path)
+    } else {
+      None
+    }
+  }
+
+  private def getStringOpt(configurationPath: String): Option[String] = {
+    if (config.hasPath(configurationPath)) {
+      Some(config.getString(configurationPath))
     } else {
       None
     }

--- a/src/main/scala/definiti/scalamodel/Configuration.scala
+++ b/src/main/scala/definiti/scalamodel/Configuration.scala
@@ -14,7 +14,7 @@ private[scalamodel] trait Configuration {
 private[scalamodel] case class JsonConfiguration(format: JsonFormat.Value, validation: JsonValidation.Value)
 
 private[scalamodel] object JsonFormat extends Enumeration {
-  val spray, none = Value
+  val play, spray, none = Value
 
   def fromString(value: String): Option[JsonFormat.Value] = {
     values.find(_.toString == value)

--- a/src/main/scala/definiti/scalamodel/ScalaAST.scala
+++ b/src/main/scala/definiti/scalamodel/ScalaAST.scala
@@ -80,6 +80,11 @@ object ScalaAST {
   case class Lambda(parameters: Seq[Parameter], body: Expression) extends Expression
 
   case class CallAttribute(target: Expression, name: String) extends Expression with Unambiguous
+
+  object CallAttribute {
+    def apply(target: String, name: String): CallAttribute = new CallAttribute(SimpleExpression(target), name)
+  }
+
   case class CallMethod(target: Expression, name: String, arguments: Seq[Expression]) extends Expression with Unambiguous
 
   object CallMethod {

--- a/src/main/scala/definiti/scalamodel/ScalaAST.scala
+++ b/src/main/scala/definiti/scalamodel/ScalaAST.scala
@@ -83,8 +83,14 @@ object ScalaAST {
   case class CallMethod(target: Expression, name: String, arguments: Seq[Expression]) extends Expression with Unambiguous
 
   object CallMethod {
+    def apply(target: String, name: String): CallMethod = {
+      new CallMethod(ScalaAST.SimpleExpression(target), name, Seq.empty)
+    }
     def apply(target: String, name: String, arguments: Expression*): CallMethod = {
       new CallMethod(ScalaAST.SimpleExpression(target), name, arguments)
+    }
+    def apply(target: String, name: String, arguments: String*)(implicit dummyImplicit: DummyImplicit): CallMethod = {
+      new CallMethod(ScalaAST.SimpleExpression(target), name, arguments.map(SimpleExpression))
     }
   }
 
@@ -172,7 +178,7 @@ object ScalaAST {
 
   case class ClassDef(name: String, extendz: Option[String], parameters: Seq[Parameter], body: Seq[Statement], property: Option[String], privateConstructor: Boolean) extends Statement
 
-  case class ClassVal(name: String, typ: String, body: Seq[Statement], isLazy: Boolean = false, isPrivate: Boolean = false) extends Statement
+  case class ClassVal(name: String, typ: String, body: Seq[Statement], isLazy: Boolean = false, isPrivate: Boolean = false, isImplicit: Boolean = false) extends Statement
 
   object ClassVal {
     def apply(name: String, typ: String, body: Statement*): ClassVal = new ClassVal(name, typ, body)

--- a/src/main/scala/definiti/scalamodel/builder/ClassDefinitionBuilder.scala
+++ b/src/main/scala/definiti/scalamodel/builder/ClassDefinitionBuilder.scala
@@ -42,10 +42,11 @@ trait ClassDefinitionBuilder {
     val typeVerifications = generateVerificationFromDefinedType(definedType)
     val allVerifications = generateAllVerificationFromDefinedType(definedType)
     val applyCheck = generateApplyCheck(definedType)
+    val jsonSupport = buildJsonConverter(definedType)
     Seq(
       ScalaAST.ObjectDef(
         name = definedType.name,
-        body = attributeVerifications :+ typeVerifications :+ allVerifications :+ applyCheck
+        body = (attributeVerifications :+ typeVerifications :+ allVerifications :+ applyCheck) ++ jsonSupport
       )
     )
   }

--- a/src/main/scala/definiti/scalamodel/builder/JsonBuilder.scala
+++ b/src/main/scala/definiti/scalamodel/builder/JsonBuilder.scala
@@ -1,0 +1,70 @@
+package definiti.scalamodel.builder
+
+import definiti.core.ast.DefinedType
+import definiti.scalamodel.{Configuration, JsonFormat, JsonValidation, ScalaAST}
+
+trait JsonBuilder {
+  self: ScalaModelBuilder =>
+
+  private val sprayJsonBuilder: JsonBuilderStrategy = new SprayJsonBuilder(config)
+
+  def buildJsonConverter(definedType: DefinedType): Seq[ScalaAST.Statement] = {
+    config.json.format match {
+      case JsonFormat.spray => sprayJsonBuilder.build(definedType)
+      case JsonFormat.none => Seq.empty
+    }
+  }
+}
+
+trait JsonBuilderStrategy {
+  def build(definedType: DefinedType): Seq[ScalaAST.Statement]
+}
+
+class SprayJsonBuilder(config: Configuration) extends JsonBuilderStrategy {
+  override def build(definedType: DefinedType): Seq[ScalaAST.Statement] = {
+    config.json.validation match {
+      case JsonValidation.flat => buildWithFlatValidation(definedType)
+      case JsonValidation.none => buildWithoutValidation(definedType)
+    }
+  }
+
+  private def buildWithFlatValidation(definedType: DefinedType): Seq[ScalaAST.Statement] = {
+    Seq(
+      ScalaAST.Import("spray.json.RootJsonFormat"),
+      ScalaAST.Import("definiti.native.JsonSpraySupport._"),
+      ScalaAST.ClassVal(
+        name = s"${definedType.name}Format",
+        typ = s"RootJsonFormat[${definedType.name}]",
+        isImplicit = true,
+        body = Seq(
+          ScalaAST.CallFunction(
+            target = ScalaAST.SimpleExpression("formatWithValidation"),
+            arguments = Seq(
+              ScalaAST.CallFunction(
+                s"jsonFormat${definedType.attributes.length}",
+                ScalaAST.SimpleExpression(s"${definedType.name}.apply")
+              ),
+              ScalaAST.SimpleExpression("allVerifications")
+            )
+          )
+        )
+      )
+    )
+  }
+
+  private def buildWithoutValidation(definedType: DefinedType): Seq[ScalaAST.Statement] = {
+    Seq(
+      ScalaAST.Import("spray.json.RootJsonFormat"),
+      ScalaAST.Import("definiti.native.JsonSpraySupport._"),
+      ScalaAST.ClassVal(
+        name = s"${definedType.name}Format",
+        typ = s"RootJsonFormat[${definedType.name}]",
+        isImplicit = true,
+        body = Seq(ScalaAST.CallFunction(
+          s"jsonFormat${definedType.attributes.length}",
+          ScalaAST.SimpleExpression(s"${definedType.name}.apply")
+        ))
+      )
+    )
+  }
+}

--- a/src/main/scala/definiti/scalamodel/builder/ScalaModelBuilder.scala
+++ b/src/main/scala/definiti/scalamodel/builder/ScalaModelBuilder.scala
@@ -3,10 +3,11 @@ package definiti.scalamodel.builder
 import definiti.core.ast.{Library, Namespace, Root}
 import definiti.scalamodel.{Configuration, ScalaAST}
 
-class ScalaModelBuilder(config: Configuration, val library: Library)
+class ScalaModelBuilder(val config: Configuration, val library: Library)
   extends CommonBuilder
     with ClassDefinitionBuilder
     with ExpressionBuilder
+    with JsonBuilder
     with NamedFunctionBuilder
     with PackageBuilder
     with TypeBuilder

--- a/src/main/scala/definiti/scalamodel/generator/ScalaCodeGenerator.scala
+++ b/src/main/scala/definiti/scalamodel/generator/ScalaCodeGenerator.scala
@@ -172,8 +172,9 @@ object ScalaCodeGenerator {
 
   def generateClassVal(ast: ScalaAST.ClassVal, indent: String): String = {
     val visibility = if (ast.isPrivate) "private" else ""
+    val implicitness = if (ast.isImplicit) "implicit" else ""
     val lazyness = if (ast.isLazy) "lazy" else ""
-    val declaration = s"$visibility $lazyness val ${ast.name}: ${ast.typ}".trim
+    val declaration = s"$visibility $implicitness $lazyness val ${ast.name}: ${ast.typ}".trim
     val assignation = ast.body.map(a => generateStatement(a, inc(indent))).mkString(s"\n${inc(indent)}")
     s"$declaration = $assignation"
   }

--- a/src/main/scala/definiti/scalamodel/plugin/ScalaModelGeneratorPlugin.scala
+++ b/src/main/scala/definiti/scalamodel/plugin/ScalaModelGeneratorPlugin.scala
@@ -31,6 +31,8 @@ class ScalaModelGeneratorPlugin extends GeneratorPlugin {
 
   private def jsonSources: Map[Path, String] = {
     config.json.format match {
+      case JsonFormat.play =>
+        Map(destinationDirectory.resolve("JsonPlaySupport.scala") -> nativeSourceDirectory.resolve("json").resolve("JsonPlaySupport.scala").content)
       case JsonFormat.spray =>
         Map(destinationDirectory.resolve("JsonSpraySupport.scala") -> nativeSourceDirectory.resolve("json").resolve("JsonSpraySupport.scala").content)
       case JsonFormat.none =>

--- a/src/main/scala/definiti/scalamodel/plugin/ScalaModelGeneratorPlugin.scala
+++ b/src/main/scala/definiti/scalamodel/plugin/ScalaModelGeneratorPlugin.scala
@@ -4,13 +4,15 @@ import java.nio.file.Path
 
 import definiti.core._
 import definiti.core.ast.{Library, Root}
-import definiti.scalamodel.Configuration
+import definiti.scalamodel.{FileConfiguration, JsonFormat}
 import definiti.scalamodel.builder.ScalaModelBuilder
 import definiti.scalamodel.generator.ScalaProjectGenerator
 import definiti.scalamodel.utils.Resource
 
 class ScalaModelGeneratorPlugin extends GeneratorPlugin {
-  val config = new Configuration()
+  val config = new FileConfiguration()
+  private val nativeSourceDirectory: Resource = Resource("native")
+  private val destinationDirectory: Path = config.destination.resolve("definiti").resolve("native")
 
   override def name: String = "scala-model-generator"
 
@@ -19,11 +21,21 @@ class ScalaModelGeneratorPlugin extends GeneratorPlugin {
   }
 
   def nativeSources: Map[Path, String] = {
-    val source = Resource("native")
-    val destinationDirectory = config.destination.resolve("definiti").resolve("native")
-    source.children
+    val source = nativeSourceDirectory
+    val commonSources = source.children
+      .filterNot(_.isDirectory)
       .map(file => destinationDirectory.resolve(file.name) -> file.content)
       .toMap
+    commonSources ++ jsonSources
+  }
+
+  private def jsonSources: Map[Path, String] = {
+    config.json.format match {
+      case JsonFormat.spray =>
+        Map(destinationDirectory.resolve("JsonSpraySupport.scala") -> nativeSourceDirectory.resolve("json").resolve("JsonSpraySupport.scala").content)
+      case JsonFormat.none =>
+        Map.empty
+    }
   }
 
   def generatedSources(root: Root, library: Library): Map[Path, String] = {

--- a/src/main/scala/definiti/scalamodel/utils/Resource.scala
+++ b/src/main/scala/definiti/scalamodel/utils/Resource.scala
@@ -17,6 +17,10 @@ trait Resource {
   def content: String
 
   def name: String
+
+  def resolve(filename: String): Resource
+
+  def isDirectory: Boolean
 }
 
 object Resource {
@@ -49,6 +53,10 @@ case class FileResource(file: File) extends Resource {
   }
 
   override def name: String = file.name
+
+  override def resolve(filename: String): Resource = FileResource(file.path.resolve(filename))
+
+  override def isDirectory: Boolean = file.isDirectory
 }
 
 case class JarResource(jar: JarFile, path: String) extends Resource {
@@ -85,4 +93,14 @@ case class JarResource(jar: JarFile, path: String) extends Resource {
       pathWithoutTrailingSlash
     }
   }
+
+  override def resolve(filename: String): Resource = {
+    if (path.endsWith("/")) {
+      JarResource(jar, path + filename)
+    } else {
+      JarResource(jar, path + "/" + filename)
+    }
+  }
+
+  override def isDirectory: Boolean = jar.getJarEntry(path) == null
 }

--- a/src/test/resources/samples/json/definedType.def
+++ b/src/test/resources/samples/json/definedType.def
@@ -1,0 +1,10 @@
+package my
+
+type MyFirstType {
+  myAttribute: String
+}
+
+type MySecondType {
+  myFirstAttribute: Number
+  mySecondAttribute: MyFirstType
+}

--- a/src/test/scala/definiti/scalamodel/PlayJsonSpec.scala
+++ b/src/test/scala/definiti/scalamodel/PlayJsonSpec.scala
@@ -1,0 +1,137 @@
+package definiti.scalamodel
+
+import definiti.core.ValidValue
+import definiti.scalamodel.ScalaAST._
+import definiti.scalamodel.helpers.{ConfigurationMock, EndToEndSpec}
+
+class PlayJsonSpec extends EndToEndSpec {
+  import PlayJsonSpec._
+
+  "The generator" should "generate the simple json of all defined types when no validation" in {
+    val expected = ValidValue(definedType(JsonValidation.none))
+    val output = processFile("json.definedType", configuration(JsonValidation.none))
+    output should be(expected)
+  }
+
+  it should "generate the json of all defined types with flat validation" in {
+    val expected = ValidValue(definedType(JsonValidation.flat))
+    val output = processFile("json.definedType", configuration(JsonValidation.flat))
+    output should be(expected)
+  }
+}
+
+object PlayJsonSpec {
+  import definiti.scalamodel.helpers.AstHelper._
+
+  def configuration(jsonValidation: JsonValidation.Value): Configuration = {
+    ConfigurationMock(
+      json = JsonConfiguration(
+        format = JsonFormat.play,
+        validation = jsonValidation
+      )
+    )
+  }
+
+  def definedType(validation: JsonValidation.Value): Root = {
+    Root(
+      Package(
+        "my",
+        CaseClassDef("MyFirstType", Parameter("myAttribute", "String")),
+        firstDefinedTypeObject(validation),
+        CaseClassDef("MySecondType", Parameter("myFirstAttribute", "BigDecimal"), Parameter("mySecondAttribute", "my.MyFirstType")),
+        secondDefinedTypeObject(validation)
+      )
+    )
+  }
+
+  private def firstDefinedTypeObject(validation: JsonValidation.Value): ObjectDef = {
+    ObjectDef(
+      name = "MyFirstType",
+      body = Seq(
+        attributeVerification("myAttribute", "String"),
+        typeVerifications("MyFirstType"),
+        allVerifications("MyFirstType", "myAttribute"),
+        applyCheck("MyFirstType", "myAttribute" -> "String")
+      ) ++ firstDefinedTypeJson(validation)
+    )
+  }
+
+  private def firstDefinedTypeJson(validation: JsonValidation.Value): Seq[Statement] = {
+    validation match {
+      case JsonValidation.none =>
+        Seq(
+          Import("play.api.libs.json._"),
+          Import("definiti.native.JsonPlaySupport._"),
+          ClassVal(
+            name = s"MyFirstTypeFormat",
+            typ = s"OFormat[MyFirstType]",
+            body = Seq(CallAttribute("Json", "format[MyFirstType]")),
+            isImplicit = true
+          )
+        )
+      case JsonValidation.flat =>
+        Seq(
+          Import("play.api.libs.json._"),
+          Import("definiti.native.JsonPlaySupport._"),
+          ClassVal(
+            name = s"MyFirstTypeFormat",
+            typ = s"OFormat[MyFirstType]",
+            body = Seq(
+              CallFunction(
+                target = "formatWithValidation",
+                CallAttribute("Json", "format[MyFirstType]"),
+                SimpleExpression("allVerifications")
+              )
+            ),
+            isImplicit = true
+          )
+        )
+    }
+  }
+
+  private def secondDefinedTypeObject(validation: JsonValidation.Value): ObjectDef = {
+    ObjectDef(
+      name = "MySecondType",
+      body = Seq(
+        attributeVerification("myFirstAttribute", "BigDecimal"),
+        attributeVerificationDefinedType("mySecondAttribute", "my.MyFirstType"),
+        typeVerifications("MySecondType"),
+        allVerifications("MySecondType", "myFirstAttribute", "mySecondAttribute"),
+        applyCheck("MySecondType", "myFirstAttribute" -> "BigDecimal", "mySecondAttribute" -> "my.MyFirstType")
+      ) ++ secondDefinedTypeJson(validation)
+    )
+  }
+
+  private def secondDefinedTypeJson(validation: JsonValidation.Value): Seq[Statement] = {
+    validation match {
+      case JsonValidation.none =>
+        Seq(
+          Import("play.api.libs.json._"),
+          Import("definiti.native.JsonPlaySupport._"),
+          ClassVal(
+            name = "MySecondTypeFormat",
+            typ = "OFormat[MySecondType]",
+            body = Seq(CallAttribute("Json", "format[MySecondType]")),
+            isImplicit = true
+          )
+        )
+      case JsonValidation.flat =>
+        Seq(
+          Import("play.api.libs.json._"),
+          Import("definiti.native.JsonPlaySupport._"),
+          ClassVal(
+            name = "MySecondTypeFormat",
+            typ = "OFormat[MySecondType]",
+            body = Seq(
+              CallFunction(
+                target = "formatWithValidation",
+                CallAttribute("Json", "format[MySecondType]"),
+                SimpleExpression("allVerifications")
+              )
+            ),
+            isImplicit = true
+          )
+        )
+    }
+  }
+}

--- a/src/test/scala/definiti/scalamodel/SprayJsonSpec.scala
+++ b/src/test/scala/definiti/scalamodel/SprayJsonSpec.scala
@@ -1,0 +1,143 @@
+package definiti.scalamodel
+
+import definiti.core.ValidValue
+import definiti.scalamodel.ScalaAST._
+import definiti.scalamodel.helpers.{ConfigurationMock, EndToEndSpec}
+
+class SprayJsonSpec extends EndToEndSpec {
+  import SprayJsonSpec._
+
+  "The generator" should "generate the simple json of all defined type when no validation" in {
+    val expected = ValidValue(definedType(JsonValidation.none))
+    val output = processFile("json.definedType", configuration(JsonValidation.none))
+    output should be(expected)
+  }
+
+  it should "generate the json of all defined type with flat validation" in {
+    val expected = ValidValue(definedType(JsonValidation.flat))
+    val output = processFile("json.definedType", configuration(JsonValidation.flat))
+    output should be(expected)
+  }
+}
+
+object SprayJsonSpec {
+  import definiti.scalamodel.helpers.AstHelper._
+
+  def configuration(jsonValidation: JsonValidation.Value): Configuration = {
+    ConfigurationMock(
+      json = JsonConfiguration(
+        format = JsonFormat.spray,
+        validation = jsonValidation
+      )
+    )
+  }
+
+  def definedType(validation: JsonValidation.Value): Root = {
+    Root(
+      Package(
+        "my",
+        CaseClassDef("MyFirstType", Parameter("myAttribute", "String")),
+        firstDefinedTypeObject(validation),
+        CaseClassDef("MySecondType", Parameter("myFirstAttribute", "BigDecimal"), Parameter("mySecondAttribute", "my.MyFirstType")),
+        secondDefinedTypeObject(validation)
+      )
+    )
+  }
+
+  private def firstDefinedTypeObject(validation: JsonValidation.Value): ObjectDef = {
+    ObjectDef(
+      name = "MyFirstType",
+      body = Seq(
+        attributeVerification("myAttribute", "String"),
+        typeVerifications("MyFirstType"),
+        allVerifications("MyFirstType", "myAttribute"),
+        applyCheck("MyFirstType", "myAttribute" -> "String")
+      ) ++ firstDefinedTypeJson(validation)
+    )
+  }
+
+  private def firstDefinedTypeJson(validation: JsonValidation.Value): Seq[Statement] = {
+    validation match {
+      case JsonValidation.none =>
+        Seq(
+          Import("spray.json.RootJsonFormat"),
+          Import("definiti.native.JsonSpraySupport._"),
+          ClassVal(
+            name = s"MyFirstTypeFormat",
+            typ = s"RootJsonFormat[MyFirstType]",
+            body = Seq(CallFunction(s"jsonFormat1", SimpleExpression(s"MyFirstType.apply"))),
+            isImplicit = true
+          )
+        )
+      case JsonValidation.flat =>
+        Seq(
+          Import("spray.json.RootJsonFormat"),
+          Import("definiti.native.JsonSpraySupport._"),
+          ClassVal(
+            name = s"MyFirstTypeFormat",
+            typ = s"RootJsonFormat[MyFirstType]",
+            body = Seq(
+              CallFunction(
+                target = "formatWithValidation",
+                CallFunction(
+                  target = "jsonFormat1",
+                  SimpleExpression(s"MyFirstType.apply")
+                ),
+                SimpleExpression("allVerifications")
+              )
+            ),
+            isImplicit = true
+          )
+        )
+    }
+  }
+
+  private def secondDefinedTypeObject(validation: JsonValidation.Value): ObjectDef = {
+    ObjectDef(
+      name = "MySecondType",
+      body = Seq(
+        attributeVerification("myFirstAttribute", "BigDecimal"),
+        attributeVerificationDefinedType("mySecondAttribute", "my.MyFirstType"),
+        typeVerifications("MySecondType"),
+        allVerifications("MySecondType", "myFirstAttribute", "mySecondAttribute"),
+        applyCheck("MySecondType", "myFirstAttribute" -> "BigDecimal", "mySecondAttribute" -> "my.MyFirstType")
+      ) ++ secondDefinedTypeJson(validation)
+    )
+  }
+
+  private def secondDefinedTypeJson(validation: JsonValidation.Value): Seq[Statement] = {
+    validation match {
+      case JsonValidation.none =>
+        Seq(
+          Import("spray.json.RootJsonFormat"),
+          Import("definiti.native.JsonSpraySupport._"),
+          ClassVal(
+            name = s"MySecondTypeFormat",
+            typ = s"RootJsonFormat[MySecondType]",
+            body = Seq(CallFunction(s"jsonFormat2", SimpleExpression(s"MySecondType.apply"))),
+            isImplicit = true
+          )
+        )
+      case JsonValidation.flat =>
+        Seq(
+          Import("spray.json.RootJsonFormat"),
+          Import("definiti.native.JsonSpraySupport._"),
+          ClassVal(
+            name = s"MySecondTypeFormat",
+            typ = s"RootJsonFormat[MySecondType]",
+            body = Seq(
+              CallFunction(
+                target = "formatWithValidation",
+                CallFunction(
+                  target = "jsonFormat2",
+                  SimpleExpression(s"MySecondType.apply")
+                ),
+                SimpleExpression("allVerifications")
+              )
+            ),
+            isImplicit = true
+          )
+        )
+    }
+  }
+}

--- a/src/test/scala/definiti/scalamodel/helpers/AstHelper.scala
+++ b/src/test/scala/definiti/scalamodel/helpers/AstHelper.scala
@@ -7,6 +7,14 @@ object AstHelper {
     ClassVal(s"${name}Verification", s"Verification[${typ}]", CallMethod("Verification", "traverse"))
   }
 
+  def attributeVerificationDefinedType(name: String, typ: String): ClassVal = {
+    ClassVal(
+      name = s"${name}Verification",
+      typ = s"Verification[${typ}]",
+      body = CallMethod("Verification", "traverse", CallAttribute(SimpleExpression("my.MyFirstType"),"allVerifications"))
+    )
+  }
+
   def typeVerifications(typ: String): ClassVal = {
     typeVerifications(typ, typ)
   }

--- a/src/test/scala/definiti/scalamodel/helpers/ConfigurationMock.scala
+++ b/src/test/scala/definiti/scalamodel/helpers/ConfigurationMock.scala
@@ -2,13 +2,12 @@ package definiti.scalamodel.helpers
 
 import java.nio.file.{Path, Paths}
 
-import definiti.core._
+import definiti.scalamodel.{Configuration, JsonConfiguration, JsonFormat, JsonValidation}
 
 case class ConfigurationMock(
-  source: Path = Paths.get(""),
-  apiSource: Path = Paths.get(""),
-  parsers: Seq[ParserPlugin] = Seq.empty,
-  validators: Seq[ValidatorPlugin] = Seq.empty,
-  generators: Seq[GeneratorPlugin] = Seq.empty,
-  contexts: Seq[ContextPlugin[_]] = Seq.empty
+  destination: Path = Paths.get(""),
+  json: JsonConfiguration = JsonConfiguration(
+    format = JsonFormat.none,
+    validation = JsonValidation.none
+  )
 ) extends Configuration

--- a/src/test/scala/definiti/scalamodel/helpers/CoreConfigurationMock.scala
+++ b/src/test/scala/definiti/scalamodel/helpers/CoreConfigurationMock.scala
@@ -1,0 +1,14 @@
+package definiti.scalamodel.helpers
+
+import java.nio.file.{Path, Paths}
+
+import definiti.core._
+
+case class CoreConfigurationMock(
+  source: Path = Paths.get(""),
+  apiSource: Path = Paths.get(""),
+  parsers: Seq[ParserPlugin] = Seq.empty,
+  validators: Seq[ValidatorPlugin] = Seq.empty,
+  generators: Seq[GeneratorPlugin] = Seq.empty,
+  contexts: Seq[ContextPlugin[_]] = Seq.empty
+) extends Configuration

--- a/src/test/scala/definiti/scalamodel/helpers/EndToEndSpec.scala
+++ b/src/test/scala/definiti/scalamodel/helpers/EndToEndSpec.scala
@@ -8,35 +8,35 @@ import definiti.scalamodel.{Configuration, ScalaAST}
 import org.scalatest.{FlatSpec, Matchers}
 
 trait EndToEndSpec extends FlatSpec with Matchers {
-  def processDirectory(sample: String): Validated[ScalaAST.Root] = {
-    process(configurationDirectory(sample))
+  def processDirectory(sample: String, configuration: Configuration = ConfigurationMock()): Validated[ScalaAST.Root] = {
+    process(configurationDirectory(sample), configuration)
   }
 
   def configurationDirectory(sample: String): CoreConfiguration = {
-    ConfigurationMock(
+    CoreConfigurationMock(
       source = Paths.get(s"src/test/resources/samples/${sample.replaceAll("\\.", "/")}"),
       apiSource = Paths.get(s"src/main/resources/api"),
       contexts = Seq()
     )
   }
 
-  def processFile(sample: String): Validated[ScalaAST.Root] = {
-    process(configurationFile(sample))
+  def processFile(sample: String, configuration: Configuration = ConfigurationMock()): Validated[ScalaAST.Root] = {
+    process(configurationFile(sample), configuration)
   }
 
   def configurationFile(sample: String): CoreConfiguration = {
-    ConfigurationMock(
+    CoreConfigurationMock(
       source = Paths.get(s"src/test/resources/samples/${sample.replaceAll("\\.", "/")}.def"),
       apiSource = Paths.get(s"src/main/resources/api"),
       contexts = Seq()
     )
   }
 
-  private def process(configuration: CoreConfiguration): Validated[ScalaAST.Root] = {
-    val project = new Project(configuration)
+  private def process(coreConfiguration: CoreConfiguration, configuration: Configuration): Validated[ScalaAST.Root] = {
+    val project = new Project(coreConfiguration)
     project.generateStructureWithLibrary()
       .map { case (ast, library) =>
-        val builder = new ScalaModelBuilder(new Configuration(), library)
+        val builder = new ScalaModelBuilder(configuration, library)
         builder.build(ast)
       }
   }


### PR DESCRIPTION
Because in lot of cases, the model needs to be serialized into JSON,
we provide implicit conversions into json.

In scala, there is several libraries to use JSON.
This pull-request do it for spray json (used in akka-http) and play json.

If wanted, it is possible to directly validate the read value (configurable).

This pull-request does the following:

* Create the `JsonSpraySupport` and `JsonPlaySupport` in case spray/play json support is enabled
* Create the `JsonBuilder` trait to build json parsers with a strategy pattern to choose the format
* Include the json statements for defined types

See commits for more information