### PR TITLE
Tree verification - Verifications now give the path to the invalid field

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,8 +18,14 @@ libraryDependencies += "org.slf4j" % "slf4j-simple" % "1.7.25"
 libraryDependencies += "com.github.pathikrit" %% "better-files" % "3.0.0"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+libraryDependencies += "org.scalacheck" %% "scalacheck" % "1.13.5" % "test"
+libraryDependencies += "com.47deg" %% "scalacheck-toolbox-datetime" % "0.2.3" % "test"
+
+libraryDependencies += "com.typesafe.play" %% "play-json" % "2.6.8" % "test"
 
 scalacOptions ++= Seq("-unchecked", "-deprecation", "-language:implicitConversions", "-feature")
+
+unmanagedSourceDirectories in Test += baseDirectory.value / "src" / "main" / "resources" / "native"
 
 useGpg := true
 

--- a/src/main/resources/native/Validation.scala
+++ b/src/main/resources/native/Validation.scala
@@ -10,59 +10,12 @@ sealed trait Validation[+A] {
   def andThen[B](f: => Validation[B]): Validation[B]
 }
 
-object Validation {
-  def apply[A, B](fa: => Validation[A])(map: A => B)(verify: B => Boolean): Validation[B] = {
-    fa match {
-      case Valid(va) =>
-        val vb = map(va)
-        if (verify(vb)) {
-          Valid(vb)
-        } else {
-          Invalid()
-        }
-    }
-  }
-
-  type V[A] = Validation[A]
-
-  def all[A, B](va: V[A], vb: V[B]): V[(A, B)] = {
-    (va, vb) match {
-      case (Valid(a), Valid(b)) => Valid((a, b))
-      case _ => Invalid(collectErrors(va, vb))
-    }
-  }
-  def all[A, B, C](va: V[A], vb: V[B], vc: V[C]): V[(A, B, C)] = {
-    (va, vb, vc) match {
-      case (Valid(a), Valid(b), Valid(c)) => Valid((a, b, c))
-      case _ => Invalid(collectErrors(va, vb, vc))
-    }
-  }
-  def all[A, B, C, D](va: V[A], vb: V[B], vc: V[C], vd: V[D]): V[(A, B, C, D)] = {
-    (va, vb, vc, vd) match {
-      case (Valid(a), Valid(b), Valid(c), Valid(d)) => Valid((a, b, c, d))
-      case _ => Invalid(collectErrors(va, vb, vc, vd))
-    }
-  }
-  def all[A, B, C, D, E](va: V[A], vb: V[B], vc: V[C], vd: V[D], ve: V[E]): V[(A, B, C, D, E)] = {
-    (va, vb, vc, vd, ve) match {
-      case (Valid(a), Valid(b), Valid(c), Valid(d), Valid(e)) => Valid((a, b, c, d, e))
-      case _ => Invalid(collectErrors(va, vb, vc, vd, ve))
-    }
-  }
-
-  def collectErrors(validations: Validation[_]*): Seq[String] = {
-    validations
-      .collect { case Invalid(errors) => errors }
-      .flatten
-  }
-}
-
 case class Valid[+A](value: A) extends Validation[A] {
   override def isValid: Boolean = true
 
   override def map[B](f: A => B): Validation[B] = Valid(f(value))
 
-  override def flatMap[B](f: A => Validation[B]) = f(value)
+  override def flatMap[B](f: A => Validation[B]): Validation[B] = f(value)
 
   override def andThen[B](f: => Validation[B]): Validation[B] = f
 }
@@ -72,7 +25,7 @@ case class Invalid(errors: Seq[String]) extends Validation[Nothing] {
 
   override def map[B](f: (Nothing) => B): Validation[B] = Invalid(errors)
 
-  override def flatMap[B](f: Nothing => Validation[B]) = Invalid(errors)
+  override def flatMap[B](f: Nothing => Validation[B]): Validation[Nothing] = Invalid(errors)
 
   override def andThen[B](f: => Validation[B]): Validation[B] = Invalid(errors)
 }

--- a/src/main/resources/native/Verification.scala
+++ b/src/main/resources/native/Verification.scala
@@ -33,10 +33,7 @@ object Verification {
     traverse(verifications)
   }
   def traverse[A](verifications: Seq[Verification[A]]): Verification[A] = {
-    verifications.toList match {
-      case Nil => new NoVerification[A]
-      case head :: tail => head.andThen(traverse(tail))
-    }
+    new VerificationGroup(verifications)
   }
 }
 
@@ -98,6 +95,7 @@ final class ListVerification[A](verification: Verification[A] = Verification[A](
 final class OptionVerification[A](verification: Verification[A] = Verification[A]()) extends Verification[Option[A]] {
   override def verify[B <: Option[A]](value: B) = {
     value
+      .map(verification.verify)
       .map {
         case Valid(_) => Valid(value)
         case Invalid(errors) => Invalid(errors)

--- a/src/main/resources/native/json/JsonPlaySupport.scala
+++ b/src/main/resources/native/json/JsonPlaySupport.scala
@@ -29,7 +29,7 @@ object JsonPlaySupport {
       defaultFormat.reads(json).flatMap { value =>
         verification.verify(value) match {
           case Valid(value) => JsSuccess(value)
-          case Invalid(errors) => JsError(Seq(JsPath() -> Seq(JsonValidationError(errors))))
+          case Invalid(errors) => JsError(Seq(JsPath() -> Seq(JsonValidationError(errors.flatMap(_.messages)))))
         }
       }
     }

--- a/src/main/resources/native/json/JsonPlaySupport.scala
+++ b/src/main/resources/native/json/JsonPlaySupport.scala
@@ -29,10 +29,30 @@ object JsonPlaySupport {
       defaultFormat.reads(json).flatMap { value =>
         verification.verify(value) match {
           case Valid(value) => JsSuccess(value)
-          case Invalid(errors) => JsError(Seq(JsPath() -> Seq(JsonValidationError(errors.flatMap(_.messages)))))
+          case Invalid(errors) => JsError(
+            errors.map { error =>
+              pathToJsonPath(error.path) -> Seq(JsonValidationError(error.messages))
+            }
+          )
         }
       }
     }
     OFormat(reads, defaultFormat)
+  }
+
+  private def pathToJsonPath(path: String): JsPath = {
+    val normalizedPath = path
+      .replaceAll("\\]\\.", ".")
+      .replaceAll("\\[", ".")
+
+    val parts = normalizedPath.split("\\.")
+    val nodes = parts.map { part =>
+      try {
+        IdxPathNode(part.toInt)
+      } catch {
+        case _: Exception => KeyPathNode(part)
+      }
+    }
+    JsPath(nodes.toList)
   }
 }

--- a/src/main/scala/definiti/scalamodel/builder/ClassDefinitionBuilder.scala
+++ b/src/main/scala/definiti/scalamodel/builder/ClassDefinitionBuilder.scala
@@ -134,10 +134,13 @@ trait ClassDefinitionBuilder {
       ScalaAST.CallMethod(
         target = ScalaAST.SimpleExpression(s"${attribute.name}Verification"),
         name = "from",
-        arguments = Seq(ScalaAST.Lambda(
-          parameters = Seq(ScalaAST.Parameter("x", typ = s"${definedType.name}${generateGenerics(definedType.genericTypes)}")),
-          body = ScalaAST.CallAttribute(ScalaAST.SimpleExpression("x"), attribute.name)
-        ))
+        arguments = Seq(
+          ScalaAST.Lambda(
+            parameters = Seq(ScalaAST.Parameter("x", typ = s"${definedType.name}${generateGenerics(definedType.genericTypes)}")),
+            body = ScalaAST.CallAttribute(ScalaAST.SimpleExpression("x"), attribute.name)
+          ),
+          ScalaAST.StringExpression(attribute.name)
+        )
       )
     }
     generateDefOrVal(

--- a/src/test/scala/definiti/common/Generators.scala
+++ b/src/test/scala/definiti/common/Generators.scala
@@ -1,0 +1,28 @@
+package definiti.common
+
+import com.fortysevendeg.scalacheck.datetime.jdk8.GenJdk8
+import org.scalacheck.Gen
+
+object Generators {
+  val anyInt = Gen.chooseNum(Int.MinValue / 2, Int.MaxValue / 2)
+  val positiveInt = Gen.posNum[Int]
+  val negativeInt = Gen.negNum[Int]
+
+  val anyString = Gen.alphaStr
+  val nonEmptyString = for {
+    firstChar <- Gen.alphaChar
+    str <- Gen.alphaStr
+  } yield firstChar + str
+
+  val anyDate = GenJdk8.genZonedDateTime.map(_.toLocalDateTime)
+  val twoOrderedDates = for {
+    date1 <- anyDate
+    date2 <- anyDate
+  } yield {
+    if (date1.isBefore(date2)) {
+      (date1, date2)
+    } else {
+      (date2, date1)
+    }
+  }
+}

--- a/src/test/scala/definiti/common/ValidationMatcher.scala
+++ b/src/test/scala/definiti/common/ValidationMatcher.scala
@@ -1,0 +1,37 @@
+package definiti.common
+
+import definiti.native.{Invalid, Valid, Validation}
+import org.scalatest.matchers.{MatchResult, Matcher}
+
+trait ValidationMatcher {
+
+  class ValidationMatcher[A](expected: Validation[A]) extends Matcher[Validation[A]] {
+
+    def apply(left: Validation[A]): MatchResult = {
+      (expected, left) match {
+        case (Valid(expectedValue), Valid(gotValue)) =>
+          if (expectedValue == gotValue) {
+            success
+          } else {
+            failed(expected, left)
+          }
+        case (Valid(_), Invalid(_)) => failed(expected, left)
+        case (Invalid(_), Valid(_)) => failed(expected, left)
+        case (expectedInvalid: Invalid, gotInvalid: Invalid) =>
+          if (expectedInvalid.errors.sortBy(_.path) == gotInvalid.errors.sortBy(_.path)) {
+            success
+          } else {
+            failed(expected, left)
+          }
+      }
+    }
+
+    private def failed(expected: Validation[A], got: Validation[A]) = MatchResult(matches = false, s"${expected} did not equal ${got}", "")
+
+    private val success = MatchResult(matches = true, "", "")
+  }
+
+  def beValidation[A](expected: Validation[A]): ValidationMatcher[A] = new ValidationMatcher[A](expected)
+}
+
+object ValidationMatcher extends ValidationMatcher

--- a/src/test/scala/definiti/native/ValidationSpec.scala
+++ b/src/test/scala/definiti/native/ValidationSpec.scala
@@ -49,8 +49,8 @@ class ValidationSpec extends FlatSpec with Matchers with PropertyChecks {
     } yield (n, message)
 
     forAll(cases) { case (n, message) =>
-      val result = Valid(n).flatMap(x => Invalid(s"${x} ${message}"))
-      result should ===(Invalid(s"${n} ${message}"))
+      val result = Valid(n).flatMap(x => Invalid.root(s"${x} ${message}"))
+      result should ===(Invalid.root(s"${n} ${message}"))
     }
   }
 
@@ -62,9 +62,9 @@ class ValidationSpec extends FlatSpec with Matchers with PropertyChecks {
 
     forAll(cases) { case (n, message) =>
       val result = Valid(n)
-        .flatMap[Int](x => Invalid(s"${x} ${message}"))
+        .flatMap[Int](x => Invalid.root(s"${x} ${message}"))
         .map(x => x * x)
-      result should ===(Invalid(s"${n} ${message}"))
+      result should ===(Invalid.root(s"${n} ${message}"))
     }
   }
 
@@ -76,9 +76,9 @@ class ValidationSpec extends FlatSpec with Matchers with PropertyChecks {
 
     forAll(cases) { case (n, message) =>
       val result = Valid(n)
-        .flatMap[Int](x => Invalid(s"${x} ${message}"))
+        .flatMap[Int](x => Invalid.root(s"${x} ${message}"))
         .flatMap(x => Valid(x * x))
-      result should ===(Invalid(s"${n} ${message}"))
+      result should ===(Invalid.root(s"${n} ${message}"))
     }
   }
 
@@ -96,21 +96,21 @@ class ValidationSpec extends FlatSpec with Matchers with PropertyChecks {
     } yield (n, message)
 
     forAll(cases) { case (n, message) =>
-      val result = Valid(n).andThen(Invalid(message))
-      result should ===(Invalid(message))
+      val result = Valid(n).andThen(Invalid.root(message))
+      result should ===(Invalid.root(message))
     }
   }
 
   "Invalid.isValid" should "return false" in {
     forAll(Generators.anyString) { message =>
-      Invalid(message).isValid should ===(false)
+      Invalid.root(message).isValid should ===(false)
     }
   }
 
   "Invalid.map" should "be a Invalid with the same error" in {
     forAll(Generators.anyString) { message =>
       val result = invalid[Int](message).map(x => x + x)
-      result should ===(Invalid(message))
+      result should ===(Invalid.root(message))
     }
   }
 
@@ -119,14 +119,14 @@ class ValidationSpec extends FlatSpec with Matchers with PropertyChecks {
       val result = invalid[Int](message)
         .map(x => x + x)
         .map(x => x * x)
-      result should ===(Invalid(message))
+      result should ===(Invalid.root(message))
     }
   }
 
   "Invalid.flatMap" should "be the initial Invalid value" in {
     forAll(Generators.anyString) { message =>
       val result = invalid[Int](message).flatMap(x => Valid(x + x))
-      result should ===(Invalid(message))
+      result should ===(Invalid.root(message))
     }
   }
 
@@ -135,7 +135,7 @@ class ValidationSpec extends FlatSpec with Matchers with PropertyChecks {
       val result = invalid[Int](message)
         .flatMap(x => Valid(x + x))
         .flatMap(x => Valid(x * x))
-      result should ===(Invalid(message))
+      result should ===(Invalid.root(message))
     }
   }
 
@@ -145,8 +145,8 @@ class ValidationSpec extends FlatSpec with Matchers with PropertyChecks {
       otherMessage <- Generators.anyString
     } yield (messages, otherMessage)
     forAll(cases) { case (message, otherMessage) =>
-      val result = invalid[Int](message).flatMap(x => Invalid(s"${x} ${otherMessage}"))
-      result should ===(Invalid(message))
+      val result = invalid[Int](message).flatMap(x => Invalid.root(s"${x} ${otherMessage}"))
+      result should ===(Invalid.root(message))
     }
   }
 
@@ -156,17 +156,17 @@ class ValidationSpec extends FlatSpec with Matchers with PropertyChecks {
       otherMessage <- Generators.anyString
     } yield (messages, otherMessage)
     forAll(cases) { case (message, otherMessage) =>
-      val result = Invalid(message).andThen(Invalid(otherMessage))
-      result should ===(Invalid(message))
+      val result = Invalid.root(message).andThen(Invalid.root(otherMessage))
+      result should ===(Invalid.root(message))
     }
   }
 
   it should "not be changed into a valid value" in {
     forAll(Generators.anyString) { message =>
-      val result = Invalid(message).andThen(Valid(1))
-      result should ===(Invalid(message))
+      val result = Invalid.root(message).andThen(Valid(1))
+      result should ===(Invalid.root(message))
     }
   }
 
-  private def invalid[A](errorMessage: String): Validation[A] = Invalid(errorMessage)
+  private def invalid[A](errorMessage: String): Validation[A] = Invalid.root(errorMessage)
 }

--- a/src/test/scala/definiti/native/ValidationSpec.scala
+++ b/src/test/scala/definiti/native/ValidationSpec.scala
@@ -1,0 +1,172 @@
+package definiti.native
+
+import definiti.common.Generators
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+class ValidationSpec extends FlatSpec with Matchers with PropertyChecks {
+  "Valid.isValid" should "return true" in {
+    forAll(Generators.anyInt) { n =>
+      Valid(n).isValid should ===(true)
+    }
+  }
+
+  "Valid.map" should "be a Valid value from the one returned by the given function" in {
+    forAll(Generators.anyInt) { n =>
+      Valid(n).map(x => x + x) should ===(Valid(n + n))
+    }
+  }
+
+  it should "be transitive" in {
+    forAll(Generators.anyInt) { n =>
+      val result = Valid(n)
+        .map(x => x + x)
+        .map(x => x * x)
+      result should ===(Valid((n + n) * (n + n)))
+    }
+  }
+
+  "Valid.flatMap" should "be the Valid value returned by the function" in {
+    forAll(Generators.anyInt) { n =>
+      val result = Valid(n).flatMap(x => Valid(x + x))
+      result should ===(Valid(n + n))
+    }
+  }
+
+  it should "be transitive" in {
+    forAll(Generators.anyInt) { n =>
+      val result = Valid(n)
+        .flatMap(x => Valid(x + x))
+        .flatMap(x => Valid(x * x))
+      result should ===(Valid((n + n) * (n + n)))
+    }
+  }
+
+  it should "be an Invalid value with errors returned by the function" in {
+    val cases = for {
+      n <- Generators.anyInt
+      message <- Generators.anyString
+    } yield (n, message)
+
+    forAll(cases) { case (n, message) =>
+      val result = Valid(n).flatMap(x => Invalid(s"${x} ${message}"))
+      result should ===(Invalid(s"${n} ${message}"))
+    }
+  }
+
+  it should "stay an Invalid value by transition (map)" in {
+    val cases = for {
+      n <- Generators.anyInt
+      message <- Generators.anyString
+    } yield (n, message)
+
+    forAll(cases) { case (n, message) =>
+      val result = Valid(n)
+        .flatMap[Int](x => Invalid(s"${x} ${message}"))
+        .map(x => x * x)
+      result should ===(Invalid(s"${n} ${message}"))
+    }
+  }
+
+  it should "stay an Invalid value by transition (flatMap)" in {
+    val cases = for {
+      n <- Generators.anyInt
+      message <- Generators.anyString
+    } yield (n, message)
+
+    forAll(cases) { case (n, message) =>
+      val result = Valid(n)
+        .flatMap[Int](x => Invalid(s"${x} ${message}"))
+        .flatMap(x => Valid(x * x))
+      result should ===(Invalid(s"${n} ${message}"))
+    }
+  }
+
+  "Valid.andThen" should "return the given Valid value" in {
+    forAll(Generators.anyInt) { n =>
+      val result = Valid(n).andThen(Valid(n + 1))
+      result should ===(Valid(n + 1))
+    }
+  }
+
+  it should "return the given Invalid value" in {
+    val cases = for {
+      n <- Generators.anyInt
+      message <- Generators.anyString
+    } yield (n, message)
+
+    forAll(cases) { case (n, message) =>
+      val result = Valid(n).andThen(Invalid(message))
+      result should ===(Invalid(message))
+    }
+  }
+
+  "Invalid.isValid" should "return false" in {
+    forAll(Generators.anyString) { message =>
+      Invalid(message).isValid should ===(false)
+    }
+  }
+
+  "Invalid.map" should "be a Invalid with the same error" in {
+    forAll(Generators.anyString) { message =>
+      val result = invalid[Int](message).map(x => x + x)
+      result should ===(Invalid(message))
+    }
+  }
+
+  it should "be transitive" in {
+    forAll(Generators.anyString) { message =>
+      val result = invalid[Int](message)
+        .map(x => x + x)
+        .map(x => x * x)
+      result should ===(Invalid(message))
+    }
+  }
+
+  "Invalid.flatMap" should "be the initial Invalid value" in {
+    forAll(Generators.anyString) { message =>
+      val result = invalid[Int](message).flatMap(x => Valid(x + x))
+      result should ===(Invalid(message))
+    }
+  }
+
+  it should "be transitive" in {
+    forAll(Generators.anyString) { message =>
+      val result = invalid[Int](message)
+        .flatMap(x => Valid(x + x))
+        .flatMap(x => Valid(x * x))
+      result should ===(Invalid(message))
+    }
+  }
+
+  it should "stay the initial Invalid" in {
+    val cases = for {
+      messages <- Generators.anyString
+      otherMessage <- Generators.anyString
+    } yield (messages, otherMessage)
+    forAll(cases) { case (message, otherMessage) =>
+      val result = invalid[Int](message).flatMap(x => Invalid(s"${x} ${otherMessage}"))
+      result should ===(Invalid(message))
+    }
+  }
+
+  "Invalid.andThen" should "return the initial Invalid value" in {
+    val cases = for {
+      messages <- Generators.anyString
+      otherMessage <- Generators.anyString
+    } yield (messages, otherMessage)
+    forAll(cases) { case (message, otherMessage) =>
+      val result = Invalid(message).andThen(Invalid(otherMessage))
+      result should ===(Invalid(message))
+    }
+  }
+
+  it should "not be changed into a valid value" in {
+    forAll(Generators.anyString) { message =>
+      val result = Invalid(message).andThen(Valid(1))
+      result should ===(Invalid(message))
+    }
+  }
+
+  private def invalid[A](errorMessage: String): Validation[A] = Invalid(errorMessage)
+}

--- a/src/test/scala/definiti/native/VerificationSeasonSamplesSpec.scala
+++ b/src/test/scala/definiti/native/VerificationSeasonSamplesSpec.scala
@@ -1,0 +1,121 @@
+package definiti.native
+
+import java.time.LocalDateTime
+
+import definiti.common.Generators
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.Random
+
+class VerificationSeasonSamplesSpec extends FlatSpec with Matchers with PropertyChecks {
+  object SeasonModel {
+    case class Season(period: Period, activities: List[String])
+    case class Period(start: LocalDateTime, end: LocalDateTime)
+
+    val periodInvalidMessage = "The start of the period should be before the end"
+    val periodVerification = Verification(periodInvalidMessage) {
+      period: Period => period.start.isBefore(period.end) || period.start.isEqual(period.end)
+    }
+
+    val activityInvalidMessage = "The activity cannot be empty"
+    val nonEmptyActivityVerification = Verification(activityInvalidMessage) {
+      activity: String => activity.nonEmpty
+    }
+
+    val activitiesInvalidMessage = "Please provide at least one activity"
+    val atLeastOneActivityVerification = Verification(activitiesInvalidMessage) {
+      activities: List[String] => activities.nonEmpty
+    }
+
+    val activitiesVerification = Verification.traverse(new ListVerification[String](nonEmptyActivityVerification), atLeastOneActivityVerification)
+
+    val seasonVerification = Verification.traverse(
+      periodVerification.from((x: Season) => x.period),
+      activitiesVerification.from((x: Season) => x.activities)
+    )
+  }
+
+  object SeasonGenerators {
+    val atLeastOneEmptyActivityGen = for {
+      validActivities <- Gen.listOf(Generators.nonEmptyString)
+      invalidActivities <- Gen.nonEmptyListOf(Gen.const(""))
+    } yield Random.shuffle(validActivities ++ invalidActivities)
+  }
+
+  import SeasonModel._
+  import SeasonGenerators._
+
+  "Verification - sample Season" should "validate a valid value" in {
+    val cases = for {
+      dates <- Generators.twoOrderedDates
+      activities <- Gen.nonEmptyListOf(Generators.nonEmptyString)
+    } yield Season(Period(dates._1, dates._2), activities)
+
+    forAll(cases) { season =>
+      seasonVerification.verify(season) should === (Valid(season))
+    }
+  }
+
+  it should "return the period error when the period is invalid" in {
+    val cases = for {
+      dates <- Generators.twoOrderedDates.suchThat(x => !x._1.isEqual(x._2))
+      activities <- Gen.nonEmptyListOf(Generators.nonEmptyString)
+    } yield Season(Period(dates._2, dates._1), activities)
+
+    forAll(cases) { season =>
+      seasonVerification.verify(season) should === (Invalid(periodInvalidMessage))
+    }
+  }
+
+  it should "return the activities error when there is no activity" in {
+    val cases = for {
+      dates <- Generators.twoOrderedDates
+    } yield Season(Period(dates._1, dates._2), List.empty)
+
+    forAll(cases) { season =>
+      seasonVerification.verify(season) should === (Invalid(activitiesInvalidMessage))
+    }
+  }
+
+  it should "return the activity error when there is at least one invalid activity" in {
+    val cases = for {
+      dates <- Generators.twoOrderedDates
+      activities <- atLeastOneEmptyActivityGen
+    } yield Season(Period(dates._1, dates._2), activities)
+
+    forAll(cases) { season =>
+      val result = seasonVerification.verify(season)
+      result shouldBe an[Invalid]
+      result.asInstanceOf[Invalid].errors.head should === (activityInvalidMessage)
+    }
+  }
+
+  it should "return an invalid value for all invalid cases" in {
+    val cases = for {
+      dates <- Generators.twoOrderedDates.suchThat(x => !x._1.isEqual(x._2))
+      activities <- Gen.oneOf(Gen.const(List.empty), atLeastOneEmptyActivityGen)
+    } yield Season(Period(dates._2, dates._1), activities)
+
+    forAll(cases) { season =>
+      seasonVerification.verify(season) shouldBe an[Invalid]
+    }
+  }
+
+  it should "return the invalid messages only (1)" in {
+    val season = Season(
+      Period(LocalDateTime.of(2018, 1, 1, 0, 0), LocalDateTime.of(2017, 12, 31, 23, 59)),
+      List.empty
+    )
+    seasonVerification.verify(season) should === (Invalid(periodInvalidMessage, activitiesInvalidMessage))
+  }
+
+  it should "return the invalid messages only (2)" in {
+    val season = Season(
+      Period(LocalDateTime.of(2018, 1, 1, 0, 0), LocalDateTime.of(2017, 12, 31, 23, 59)),
+      List("", "")
+    )
+    seasonVerification.verify(season) should === (Invalid(periodInvalidMessage, activityInvalidMessage, activityInvalidMessage))
+  }
+}

--- a/src/test/scala/definiti/native/VerificationSeasonSamplesSpec.scala
+++ b/src/test/scala/definiti/native/VerificationSeasonSamplesSpec.scala
@@ -3,22 +3,119 @@ package definiti.native
 import java.time.LocalDateTime
 
 import definiti.common.Generators
+import definiti.common.ValidationMatcher
 import org.scalacheck.Gen
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.util.Random
 
-class VerificationSeasonSamplesSpec extends FlatSpec with Matchers with PropertyChecks {
-  object SeasonModel {
-    case class Season(period: Period, activities: List[String])
-    case class Period(start: LocalDateTime, end: LocalDateTime)
+class VerificationSeasonSamplesSpec extends FlatSpec with Matchers with PropertyChecks with ValidationMatcher {
+  import VerificationSeasonSamplesSpec._
 
-    val periodInvalidMessage = "The start of the period should be before the end"
-    val periodVerification = Verification(periodInvalidMessage) {
-      period: Period => period.start.isBefore(period.end) || period.start.isEqual(period.end)
+  "Verification - sample Season" should "validate a valid value" in {
+    val cases = for {
+      dates <- Generators.twoOrderedDates
+      activities <- Gen.nonEmptyListOf(Generators.nonEmptyString)
+    } yield Season(Period(dates._1, dates._2), activities, List.empty)
+
+    forAll(cases) { season =>
+      Season.seasonVerification.verify(season) should === (Valid(season))
     }
+  }
 
+  it should "return the period error when the period is invalid" in {
+    val cases = for {
+      dates <- Generators.twoOrderedDates.suchThat(x => !x._1.isEqual(x._2))
+      activities <- Gen.nonEmptyListOf(Generators.nonEmptyString)
+    } yield Season(Period(dates._2, dates._1), activities, List.empty)
+
+    forAll(cases) { season =>
+      Season.seasonVerification.verify(season) should === (Invalid("period", Period.periodInvalidMessage))
+    }
+  }
+
+  it should "return the activities error when there is no activity" in {
+    val cases = for {
+      dates <- Generators.twoOrderedDates
+    } yield Season(Period(dates._1, dates._2), List.empty, List.empty)
+
+    forAll(cases) { season =>
+      Season.seasonVerification.verify(season) should === (Invalid("activities", Season.activitiesInvalidMessage))
+    }
+  }
+
+  it should "return the activity error when there is at least one invalid activity" in {
+    val cases = for {
+      dates <- Generators.twoOrderedDates
+      activities <- atLeastOneEmptyActivityGen
+    } yield Season(Period(dates._1, dates._2), activities, List.empty)
+
+    forAll(cases) { season =>
+      val result = Season.seasonVerification.verify(season)
+      val expectedErrors = season.activities.zipWithIndex.filter(_._1.isEmpty).map { case (_, n) => Error(s"activities[${n}]", Season.activityInvalidMessage) }
+      result should beValidation[Season](Invalid(expectedErrors))
+    }
+  }
+
+  it should "return an invalid value for all invalid cases" in {
+    val cases = for {
+      dates <- Generators.twoOrderedDates.suchThat(x => !x._1.isEqual(x._2))
+      activities <- Gen.oneOf(Gen.const(List.empty), atLeastOneEmptyActivityGen)
+    } yield Season(Period(dates._2, dates._1), activities, List.empty)
+
+    forAll(cases) { season =>
+      Season.seasonVerification.verify(season) shouldBe an[Invalid]
+    }
+  }
+
+  it should "return the invalid messages only (1)" in {
+    val season = Season(
+      Period(LocalDateTime.of(2018, 1, 1, 0, 0), LocalDateTime.of(2017, 12, 31, 23, 59)),
+      List.empty,
+      List.empty
+    )
+    val expected = Invalid(
+      Error("period", Period.periodInvalidMessage),
+      Error("activities", Season.activitiesInvalidMessage)
+    )
+    Season.seasonVerification.verify(season) should beValidation[Season](expected)
+  }
+
+  it should "return the invalid messages only (2)" in {
+    val season = Season(
+      Period(LocalDateTime.of(2018, 1, 1, 0, 0), LocalDateTime.of(2017, 12, 31, 23, 59)),
+      List("", ""),
+      List.empty
+    )
+    val expected = Invalid(
+      Error("period", Period.periodInvalidMessage),
+      Error("activities[0]", Season.activityInvalidMessage),
+      Error("activities[1]", Season.activityInvalidMessage)
+    )
+    Season.seasonVerification.verify(season) should beValidation[Season](expected)
+  }
+
+  it should "return the invalid messages only (3)" in {
+    val season = Season(
+      Period(LocalDateTime.of(2018, 1, 1, 0, 0), LocalDateTime.of(2017, 12, 31, 23, 59)),
+      List("", ""),
+      List(SeasonOption(name = "", description = ""), SeasonOption(name = "valid", description = ""))
+    )
+    val expected = Invalid(
+      Error("period", Period.periodInvalidMessage),
+      Error("activities[0]", Season.activityInvalidMessage),
+      Error("activities[1]", Season.activityInvalidMessage),
+      Error("options[0].name", SeasonOption.nameInvalidMessage)
+    )
+    Season.seasonVerification.verify(season) should beValidation[Season](expected)
+  }
+}
+
+object VerificationSeasonSamplesSpec {
+  case class Season(period: Period, activities: List[String], options: List[SeasonOption])
+
+  object Season {
     val activityInvalidMessage = "The activity cannot be empty"
     val nonEmptyActivityVerification = Verification(activityInvalidMessage) {
       activity: String => activity.nonEmpty
@@ -31,91 +128,37 @@ class VerificationSeasonSamplesSpec extends FlatSpec with Matchers with Property
 
     val activitiesVerification = Verification.traverse(new ListVerification[String](nonEmptyActivityVerification), atLeastOneActivityVerification)
 
+    val optionsVerification = new ListVerification[SeasonOption](SeasonOption.seasonOptionVerification)
+
     val seasonVerification = Verification.traverse(
-      periodVerification.from((x: Season) => x.period),
-      activitiesVerification.from((x: Season) => x.activities)
+      Period.periodVerification.from((x: Season) => x.period, "period"),
+      activitiesVerification.from((x: Season) => x.activities, "activities"),
+      optionsVerification.from((x: Season) => x.options, "options")
     )
   }
 
-  object SeasonGenerators {
-    val atLeastOneEmptyActivityGen = for {
-      validActivities <- Gen.listOf(Generators.nonEmptyString)
-      invalidActivities <- Gen.nonEmptyListOf(Gen.const(""))
-    } yield Random.shuffle(validActivities ++ invalidActivities)
-  }
+  case class Period(start: LocalDateTime, end: LocalDateTime)
 
-  import SeasonModel._
-  import SeasonGenerators._
-
-  "Verification - sample Season" should "validate a valid value" in {
-    val cases = for {
-      dates <- Generators.twoOrderedDates
-      activities <- Gen.nonEmptyListOf(Generators.nonEmptyString)
-    } yield Season(Period(dates._1, dates._2), activities)
-
-    forAll(cases) { season =>
-      seasonVerification.verify(season) should === (Valid(season))
+  object Period {
+    val periodInvalidMessage = "The start of the period should be before the end"
+    val periodVerification = Verification(periodInvalidMessage) {
+      period: Period => period.start.isBefore(period.end) || period.start.isEqual(period.end)
     }
   }
 
-  it should "return the period error when the period is invalid" in {
-    val cases = for {
-      dates <- Generators.twoOrderedDates.suchThat(x => !x._1.isEqual(x._2))
-      activities <- Gen.nonEmptyListOf(Generators.nonEmptyString)
-    } yield Season(Period(dates._2, dates._1), activities)
+  case class SeasonOption(name: String, description: String)
 
-    forAll(cases) { season =>
-      seasonVerification.verify(season) should === (Invalid(periodInvalidMessage))
+  object SeasonOption {
+    val nameInvalidMessage = "The option name is empty"
+    val nameVerification = Verification(nameInvalidMessage) {
+      name: String => name.nonEmpty
     }
+
+    val seasonOptionVerification = Verification.traverse(nameVerification.from((x: SeasonOption) => x.name, "name"))
   }
 
-  it should "return the activities error when there is no activity" in {
-    val cases = for {
-      dates <- Generators.twoOrderedDates
-    } yield Season(Period(dates._1, dates._2), List.empty)
-
-    forAll(cases) { season =>
-      seasonVerification.verify(season) should === (Invalid(activitiesInvalidMessage))
-    }
-  }
-
-  it should "return the activity error when there is at least one invalid activity" in {
-    val cases = for {
-      dates <- Generators.twoOrderedDates
-      activities <- atLeastOneEmptyActivityGen
-    } yield Season(Period(dates._1, dates._2), activities)
-
-    forAll(cases) { season =>
-      val result = seasonVerification.verify(season)
-      result shouldBe an[Invalid]
-      result.asInstanceOf[Invalid].errors.head should === (activityInvalidMessage)
-    }
-  }
-
-  it should "return an invalid value for all invalid cases" in {
-    val cases = for {
-      dates <- Generators.twoOrderedDates.suchThat(x => !x._1.isEqual(x._2))
-      activities <- Gen.oneOf(Gen.const(List.empty), atLeastOneEmptyActivityGen)
-    } yield Season(Period(dates._2, dates._1), activities)
-
-    forAll(cases) { season =>
-      seasonVerification.verify(season) shouldBe an[Invalid]
-    }
-  }
-
-  it should "return the invalid messages only (1)" in {
-    val season = Season(
-      Period(LocalDateTime.of(2018, 1, 1, 0, 0), LocalDateTime.of(2017, 12, 31, 23, 59)),
-      List.empty
-    )
-    seasonVerification.verify(season) should === (Invalid(periodInvalidMessage, activitiesInvalidMessage))
-  }
-
-  it should "return the invalid messages only (2)" in {
-    val season = Season(
-      Period(LocalDateTime.of(2018, 1, 1, 0, 0), LocalDateTime.of(2017, 12, 31, 23, 59)),
-      List("", "")
-    )
-    seasonVerification.verify(season) should === (Invalid(periodInvalidMessage, activityInvalidMessage, activityInvalidMessage))
-  }
+  val atLeastOneEmptyActivityGen = for {
+    validActivities <- Gen.listOf(Generators.nonEmptyString)
+    invalidActivities <- Gen.nonEmptyListOf(Gen.const(""))
+  } yield Random.shuffle(validActivities ++ invalidActivities)
 }

--- a/src/test/scala/definiti/native/VerificationSpec.scala
+++ b/src/test/scala/definiti/native/VerificationSpec.scala
@@ -1,0 +1,107 @@
+package definiti.native
+
+import definiti.common.Generators
+import org.scalacheck.Gen
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.util.Random
+
+class VerificationSpec extends FlatSpec with Matchers with PropertyChecks {
+  "NoVerification.verify" should "return a Valid value" in {
+    forAll(Generators.anyString) { value =>
+      new NoVerification[String].verify(value) should ===(Valid(value))
+    }
+  }
+
+  "ValueVerification.verify" should "return a Valid value when the condition is valid" in {
+    val cases = for {
+      n <- Generators.positiveInt
+      message <- Generators.anyString
+    } yield (n, message)
+
+    forAll(cases) { case (n, message) =>
+      new ValueVerification[Int](x => x > 0, message).verify(n) should === (Valid(n))
+    }
+  }
+
+  it should "return an Invalid value when the condition is invalid" in {
+    val cases = for {
+      n <- Generators.negativeInt
+      message <- Generators.anyString
+    } yield (n, message)
+
+    forAll(cases) { case (n, message) =>
+      new ValueVerification[Int](x => x > 0, message).verify(n) should === (Invalid(message))
+    }
+  }
+
+  "ListVerification.verify" should "return a Valid value when the condition is valid for all values" in {
+    val cases = for {
+      values <- Gen.listOf(Generators.positiveInt)
+      message <- Generators.anyString
+    } yield (values, message)
+
+    forAll(cases) { case (values, message) =>
+      val result = new ListVerification[Int](new ValueVerification(x => x > 0, message)).verify(values)
+      result should === (Valid(values))
+    }
+  }
+
+  it should "return an Invalid value when the condition is invalid for all elements" in {
+    val cases = for {
+      values <- Gen.nonEmptyListOf(Generators.negativeInt)
+      message <- Generators.anyString
+    } yield (values, message)
+
+    forAll(cases) { case (values, message) =>
+      val result = new ListVerification[Int](new ValueVerification(x => x > 0, message)).verify(values)
+      result should === (Invalid(List.fill(values.length)(message)))
+    }
+  }
+
+  it should "return an Invalid value when the condition is invalid for at least one element" in {
+    val cases = for {
+      validValues <- Gen.listOf(Generators.positiveInt)
+      invalidValues <- Gen.nonEmptyListOf(Generators.negativeInt)
+      message <- Generators.anyString
+    } yield (validValues, invalidValues, message)
+
+    forAll(cases) { case (validValues, invalidValues, message) =>
+      val values = Random.shuffle(validValues ++ invalidValues)
+      val result = new ListVerification[Int](new ValueVerification(x => x > 0, message)).verify(values)
+      result should === (Invalid(List.fill(invalidValues.length)(message)))
+    }
+  }
+
+  "OptionVerification.verify" should "return a Valid value when the condition is valid for Some(element)" in {
+    val cases = for {
+      n <- Generators.positiveInt
+      message <- Generators.anyString
+    } yield (Some(n), message)
+
+    forAll(cases) { case (nOption, message) =>
+      val result = new OptionVerification[Int](new ValueVerification(x => x > 0, message)).verify(nOption)
+      result should === (Valid(nOption))
+    }
+  }
+
+  it should "return a Valid value when the Option is empty" in {
+    forAll(Generators.anyString) { message =>
+      val result = new OptionVerification[Int](new ValueVerification(x => x > 0, message)).verify(None)
+      result should === (Valid(None))
+    }
+  }
+
+  it should "return an Invalid value when the condition is invalid for the element" in {
+    val cases = for {
+      value <- Generators.negativeInt
+      message <- Generators.anyString
+    } yield (Some(value), message)
+
+    forAll(cases) { case (nOption, message) =>
+      val result = new OptionVerification[Int](new ValueVerification(x => x > 0, message)).verify(nOption)
+      result should === (Invalid(message))
+    }
+  }
+}

--- a/src/test/scala/definiti/scalamodel/helpers/AstHelper.scala
+++ b/src/test/scala/definiti/scalamodel/helpers/AstHelper.scala
@@ -49,7 +49,8 @@ object AstHelper {
                   Lambda(
                     parameters = Seq(Parameter("x", typ)),
                     body = CallAttribute(SimpleExpression("x"), attribute)
-                  )
+                  ),
+                  StringExpression(attribute)
                 )
               )
             }


### PR DESCRIPTION
Because we need to know which field is invalid,
we update the `Verification` and `Validation` system to specify it.

To specify the field, we use a string path as: `f1.f2[0].f3` (as javascript syntax).

The change will be done in several steps.
This one focuses on the native API.

It is a breaking change of the current version of the code.

This commit does the following:

* Update `Invalid` to receive an `Error(path, messages)` instead of messages only
* Update `Verification` to consider the updated `Invalid`
* Correct tests to show how it works
* Add `Season.options` in `VerificationSeasonSamplesSpec` for deep validation
* Add another test into `VerificationSeasonSamplesSpec` to test this deep validation
* Restructure `VerificationSeasonSamplesSpec` to clean the code