### PR TITLE
Refactor the code and simplify the generated one

### DIFF
--- a/src/main/resources/native/Verification.scala
+++ b/src/main/resources/native/Verification.scala
@@ -25,16 +25,16 @@ sealed trait Verification[A] {
 }
 
 object Verification {
-  def apply[A](): Verification[A] = new NoVerification[A]
-
   def apply[A](message: String)(check: A => Boolean): Verification[A] = {
     new ValueVerification(check, message)
   }
 
-  def traverse[A](verifications: Verification[A]*)(implicit dummyImplicit: DummyImplicit): Verification[A] = {
-    traverse(verifications)
+  def none[A]: Verification[A] = new NoVerification[A]
+
+  def all[A](verifications: Verification[A]*)(implicit dummyImplicit: DummyImplicit): Verification[A] = {
+    all(verifications)
   }
-  def traverse[A](verifications: Seq[Verification[A]]): Verification[A] = {
+  def all[A](verifications: Seq[Verification[A]]): Verification[A] = {
     new VerificationGroup(verifications)
   }
 }
@@ -76,7 +76,7 @@ final class ValueVerification[A](check: A => Boolean, message: String) extends V
   override def withMessage(message: String) = new ValueVerification(check, message)
 }
 
-final class ListVerification[A](verification: Verification[A] = Verification[A]()) extends Verification[List[A]] {
+final class ListVerification[A](verification: Verification[A] = Verification.none[A]) extends Verification[List[A]] {
   override private[native] def validate[B <: List[A]](path: String, value: B) = {
     val validations = value.zipWithIndex.map {
       case (current, index) => verification.validate(path + s"[${index}]", current)
@@ -89,7 +89,7 @@ final class ListVerification[A](verification: Verification[A] = Verification[A](
   }
 }
 
-final class OptionVerification[A](verification: Verification[A] = Verification[A]()) extends Verification[Option[A]] {
+final class OptionVerification[A](verification: Verification[A] = Verification.none[A]) extends Verification[Option[A]] {
   override private[native] def validate[B <: Option[A]](path: String, value: B) = {
     value
       .map(verification.validate(path, _))

--- a/src/main/scala/definiti/scalamodel/ScalaAST.scala
+++ b/src/main/scala/definiti/scalamodel/ScalaAST.scala
@@ -21,18 +21,21 @@ object ScalaAST {
 
   case class Package(
     name: String,
+    imports: Seq[Import],
     elements: Seq[PackageElement]
   ) extends PackageElement
 
   object Package {
-    def apply(name: String, elements: PackageElement*)(implicit dummyImplicit: DummyImplicit): Package = {
-      new Package(name, elements)
+    def apply(name: String, imports: Seq[Import], elements: PackageElement*)(implicit dummyImplicit: DummyImplicit): Package = {
+      new Package(name, imports, elements)
     }
   }
 
   case class PackageDeclaration(name: String) extends Statement
 
   case class Import(name: String) extends Statement
+
+  case object Blank extends Statement
 
   case class PackageDef(name: String, body: Seq[Statement]) extends Statement
 

--- a/src/main/scala/definiti/scalamodel/builder/ClassDefinitionBuilder.scala
+++ b/src/main/scala/definiti/scalamodel/builder/ClassDefinitionBuilder.scala
@@ -3,6 +3,7 @@ package definiti.scalamodel.builder
 import definiti.core.ast._
 import definiti.scalamodel.ScalaAST
 import definiti.scalamodel.ScalaAST.Expression
+import definiti.scalamodel.utils.StringUtils
 
 trait ClassDefinitionBuilder {
   self: ScalaModelBuilder =>
@@ -78,9 +79,9 @@ trait ClassDefinitionBuilder {
   private def generateTypeVerificationCall(typeReference: TypeReference): Option[ScalaAST.Expression] = {
     library.types.get(typeReference.typeName) match {
       case Some(aliasType: AliasType) =>
-        Some(ScalaAST.CallAttribute(ScalaAST.SimpleExpression(typeReference.typeName), s"${aliasType.name}Verifications${generateGenericTypes(typeReference.genericTypes)}"))
+        Some(ScalaAST.CallAttribute(ScalaAST.SimpleExpression(StringUtils.lastPart(typeReference.typeName)), s"${StringUtils.lastPart(aliasType.name)}Verifications${generateGenericTypes(typeReference.genericTypes)}"))
       case Some(_: DefinedType) =>
-        Some(ScalaAST.CallAttribute(ScalaAST.SimpleExpression(typeReference.typeName), s"allVerifications${generateGenericTypes(typeReference.genericTypes)}"))
+        Some(ScalaAST.CallAttribute(ScalaAST.SimpleExpression(StringUtils.lastPart(typeReference.typeName)), s"allVerifications${generateGenericTypes(typeReference.genericTypes)}"))
       case _ => None
     }
   }
@@ -91,7 +92,7 @@ trait ClassDefinitionBuilder {
 
   private def generateVerificationCall(verificationReference: VerificationReference, generics: String): ScalaAST.Expression = {
     ScalaAST.CallFunction(
-      target = ScalaAST.SimpleExpression(s"${verificationReference.verificationName}${generics}"),
+      target = ScalaAST.SimpleExpression(s"${StringUtils.lastPart(verificationReference.verificationName)}${generics}"),
       arguments = verificationReference.message.map(ScalaAST.StringExpression).toSeq
     )
   }

--- a/src/main/scala/definiti/scalamodel/builder/CommonBuilder.scala
+++ b/src/main/scala/definiti/scalamodel/builder/CommonBuilder.scala
@@ -6,8 +6,14 @@ trait CommonBuilder {
   self: ScalaModelBuilder =>
 
   val nativeTypeMapping = Map(
+    "Any" -> "Any",
+    "Boolean" -> "Boolean",
+    "Date" -> "LocalDateTime",
+    "List" -> "List",
     "Number" -> "BigDecimal",
-    "Date" -> "LocalDateTime"
+    "Option" -> "Option",
+    "String" -> "String",
+    "Unit" -> "Unit"
   )
 
   def verificationsFromNamespace(namespace: Namespace): Seq[Verification] = {

--- a/src/main/scala/definiti/scalamodel/builder/ExpressionBuilder.scala
+++ b/src/main/scala/definiti/scalamodel/builder/ExpressionBuilder.scala
@@ -2,6 +2,7 @@ package definiti.scalamodel.builder
 
 import definiti.core.ast._
 import definiti.scalamodel.ScalaAST
+import definiti.scalamodel.utils.StringUtils
 
 trait ExpressionBuilder {
   self: ScalaModelBuilder =>
@@ -27,7 +28,10 @@ trait ExpressionBuilder {
     case quotedString: QuotedStringValue =>
       ScalaAST.SimpleExpression('"' + quotedString.value.replaceAllLiterally("\\", "\\\\") + '"')
     case reference: Reference =>
-      ScalaAST.SimpleExpression(reference.name)
+      reference.returnType match {
+        case NamedFunctionReference(functionName) => ScalaAST.SimpleExpression(StringUtils.lastPart(functionName))
+        case _ => ScalaAST.SimpleExpression(reference.name)
+      }
     case methodCall: MethodCall =>
       generateMethodCall(methodCall)
     case attributeCall: AttributeCall =>
@@ -52,7 +56,7 @@ trait ExpressionBuilder {
       )
     case not: Not => ScalaAST.UnaryOp("!", generateExpression(not.inner))
     case functionCall: FunctionCall =>
-      ScalaAST.CallFunction(ScalaAST.SimpleExpression(functionCall.name), functionCall.parameters.map(generateExpression))
+      ScalaAST.CallFunction(ScalaAST.SimpleExpression(StringUtils.lastPart(functionCall.name)), functionCall.parameters.map(generateExpression))
     case lambda: LambdaExpression =>
       ScalaAST.Lambda(lambda.parameterList.map(generateParameter), generateExpression(lambda.expression))
   }

--- a/src/main/scala/definiti/scalamodel/builder/ImportExtractor.scala
+++ b/src/main/scala/definiti/scalamodel/builder/ImportExtractor.scala
@@ -1,0 +1,109 @@
+package definiti.scalamodel.builder
+
+import definiti.core.ast._
+import definiti.scalamodel.ScalaAST
+import definiti.scalamodel.utils.StringUtils
+
+trait ImportExtractor {
+  self: ScalaModelBuilder =>
+
+  protected def extractImportsFromNamespace(namespace: Namespace): Seq[ScalaAST.Import] = {
+    namespace.elements
+      .view
+      .flatMap {
+        case verification: Verification => extractFromVerification(verification)
+        case namedFunction: NamedFunction => extractFromNamedFunction(namedFunction)
+        case classDefinition: ClassDefinition => extractFromClassDefinition(classDefinition)
+        case _ => Seq.empty
+      }
+      .distinct
+      .filterNot(nativeTypeMapping.contains)
+      .filterNot(importName => StringUtils.excludeLastPart(importName) == namespace.fullName)
+      .map(ScalaAST.Import)
+      .force
+  }
+
+  private def extractFromVerification(verification: Verification): Seq[String] = {
+    extractFromDefinedFunction(verification.function)
+  }
+
+  private def extractFromDefinedFunction(definedFunction: DefinedFunction): Seq[String] = {
+    val parameterTypes = definedFunction.parameters.flatMap(extractFromParameter)
+    val bodyTypes = extractFromExpression(definedFunction.body)
+    (parameterTypes ++ bodyTypes)
+      .filterNot(definedFunction.genericTypes.contains)
+  }
+
+  private def extractFromParameter(parameter: ParameterDefinition): Seq[String] = {
+    extractFromTypeReference(parameter.typeReference)
+  }
+
+  private def extractFromTypeReference(typeReference: AbstractTypeReference): Seq[String] = {
+    typeReference match {
+      case TypeReference(typeName, genericTypes) => typeName +: genericTypes.flatMap(extractFromTypeReference)
+      case LambdaReference(inputTypes, _) => inputTypes.flatMap(extractFromTypeReference)
+      case NamedFunctionReference(functionName) => Seq(functionName)
+    }
+  }
+
+  private def extractFromNamedFunction(namedFunction: NamedFunction): Seq[String] = {
+    val parameterTypes = namedFunction.parameters.flatMap(extractFromParameter)
+    val bodyTypes = extractFromExpression(namedFunction.body)
+    val returnType = extractFromTypeReference(namedFunction.returnType)
+    (parameterTypes ++ bodyTypes ++ returnType)
+      .filterNot(namedFunction.genericTypes.contains)
+  }
+
+  private def extractFromClassDefinition(classDefinition: ClassDefinition): Seq[String] = {
+    classDefinition match {
+      case aliasType: AliasType => extractFromAliasType(aliasType)
+      case definedType: DefinedType => extractFromDefinedType(definedType)
+      case _ => Seq.empty
+    }
+  }
+
+  private def extractFromAliasType(aliasType: AliasType): Seq[String] = {
+    val aliasTypes = extractFromTypeReference(aliasType.alias)
+    val verificationTypes = aliasType.inherited.flatMap(extractFromVerificationReference)
+    (aliasTypes ++ verificationTypes)
+      .filterNot(aliasType.genericTypes.contains)
+  }
+
+  private def extractFromVerificationReference(verificationReference: VerificationReference): Seq[String] = {
+    Seq(verificationReference.verificationName)
+  }
+
+  private def extractFromDefinedType(definedType: DefinedType): Seq[String] = {
+    val verificationTypes = definedType.inherited.flatMap(extractFromVerificationReference)
+    val attributeTypes = definedType.attributes.flatMap(extractFromAttribute)
+    val expressionTypes = definedType.verifications.flatMap(verification => extractFromDefinedFunction(verification.function))
+    (verificationTypes ++ attributeTypes ++ expressionTypes)
+      .filterNot(definedType.genericTypes.contains)
+  }
+
+  private def extractFromAttribute(attributeDefinition: AttributeDefinition): Seq[String] = {
+    val attributeType = extractFromTypeReference(attributeDefinition.typeReference)
+    val verificationTypes = attributeDefinition.verifications.flatMap(extractFromVerificationReference)
+    attributeType ++ verificationTypes
+  }
+
+  private def extractFromExpression(expression: Expression): Seq[String] = {
+    expression match {
+      case logical: LogicalExpression => extractFromExpression(logical.left) ++ extractFromExpression(logical.right)
+      case calculator: CalculatorExpression => extractFromExpression(calculator.left) ++ extractFromExpression(calculator.right)
+      case not: Not => extractFromExpression(not.inner)
+      case reference: Reference =>
+        reference.returnType match {
+          case NamedFunctionReference(functionName) => Seq(functionName)
+          case _ => Seq.empty
+        }
+      case methodCall: MethodCall => extractFromExpression(methodCall.expression) ++ methodCall.parameters.flatMap(extractFromExpression)
+      case attributeCall: AttributeCall => extractFromExpression(attributeCall.expression)
+      case combinedExpression: CombinedExpression => combinedExpression.parts.flatMap(extractFromExpression)
+      case condition: Condition => extractFromExpression(condition.condition) ++ extractFromExpression(condition.onTrue) ++ condition.onFalse.toSeq.flatMap(extractFromExpression)
+      case lambdaExpression: LambdaExpression => lambdaExpression.parameterList.flatMap(extractFromParameter) ++ extractFromExpression(lambdaExpression.expression)
+      case functionCall: FunctionCall => functionCall.name +: functionCall.parameters.flatMap(extractFromExpression)
+      case _ => Seq.empty
+    }
+  }
+}

--- a/src/main/scala/definiti/scalamodel/builder/ScalaModelBuilder.scala
+++ b/src/main/scala/definiti/scalamodel/builder/ScalaModelBuilder.scala
@@ -7,6 +7,7 @@ class ScalaModelBuilder(val config: Configuration, val library: Library)
   extends CommonBuilder
     with ClassDefinitionBuilder
     with ExpressionBuilder
+    with ImportExtractor
     with JsonBuilder
     with NamedFunctionBuilder
     with PackageBuilder
@@ -35,6 +36,7 @@ class ScalaModelBuilder(val config: Configuration, val library: Library)
     }
     ScalaAST.Package(
       namespace.fullName,
+      imports = extractImportsFromNamespace(namespace),
       elements = directElements ++ packageElements
     )
   }

--- a/src/main/scala/definiti/scalamodel/builder/TypeBuilder.scala
+++ b/src/main/scala/definiti/scalamodel/builder/TypeBuilder.scala
@@ -2,7 +2,7 @@ package definiti.scalamodel.builder
 
 import definiti.core.ast._
 import definiti.scalamodel.ScalaAST
-import definiti.scalamodel.utils.ListUtils
+import definiti.scalamodel.utils.{ListUtils, StringUtils}
 
 trait TypeBuilder {
   self: ScalaModelBuilder =>
@@ -16,7 +16,7 @@ trait TypeBuilder {
 
       case LambdaReference(inputTypes, outputType) =>
         def generateOneType(typeReference: TypeReference): String = {
-          val typeName = typeReference.typeName
+          val typeName = StringUtils.lastPart(typeReference.typeName)
           val generics = generateGenericTypes(typeReference.genericTypes)
           typeName + generics
         }
@@ -35,7 +35,7 @@ trait TypeBuilder {
       case Some(aliasType: AliasType) =>
         generateMainType(aliasType.alias, ListUtils.replaceOrdered(aliasType.alias.genericTypes, outerTypeReferences))
       case _ =>
-        typeReference.typeName
+        StringUtils.lastPart(typeReference.typeName)
     }
   }
 
@@ -57,7 +57,7 @@ trait TypeBuilder {
     def generateGenericType(genericType: TypeReference): String = {
       val mainType = library.types.get(genericType.typeName) match {
         case Some(aliasType: AliasType) => generateGenericType(aliasType.alias)
-        case _ => nativeTypeMapping.getOrElse(genericType.typeName, genericType.typeName)
+        case _ => nativeTypeMapping.getOrElse(genericType.typeName, StringUtils.lastPart(genericType.typeName))
       }
       mainType + generateGenericTypes(genericType.genericTypes)
     }

--- a/src/main/scala/definiti/scalamodel/generator/ScalaCodeGenerator.scala
+++ b/src/main/scala/definiti/scalamodel/generator/ScalaCodeGenerator.scala
@@ -192,6 +192,7 @@ object ScalaCodeGenerator {
       case ast: ScalaAST.Def2 => generateDef2(ast, indent)
       case ast: ScalaAST.PackageDeclaration => generatePackageDeclaration(ast)
       case ast: ScalaAST.Import => generateImport(ast)
+      case ScalaAST.Blank => ""
       case ast: ScalaAST.PackageDef => generatePackageDef(ast, indent)
       case ast: ScalaAST.StatementsGroup => generateStatementsGroup(ast, indent)
       case ast: ScalaAST.Val => generateVal(ast, indent)

--- a/src/main/scala/definiti/scalamodel/utils/StringUtils.scala
+++ b/src/main/scala/definiti/scalamodel/utils/StringUtils.scala
@@ -1,7 +1,7 @@
 package definiti.scalamodel.utils
 
 object StringUtils {
-  def lastPart(source: String, separator: Char): String = {
+  def lastPart(source: String, separator: Char = '.'): String = {
     if (source.isEmpty) {
       source
     } else if (source.last == separator) {
@@ -13,7 +13,7 @@ object StringUtils {
     }
   }
 
-  def excludeLastPart(source: String, separator: Char): String = {
+  def excludeLastPart(source: String, separator: Char = '.'): String = {
     if (source.isEmpty) {
       source
     } else if (source.last == separator) {

--- a/src/test/scala/definiti/native/VerificationSeasonSamplesSpec.scala
+++ b/src/test/scala/definiti/native/VerificationSeasonSamplesSpec.scala
@@ -126,11 +126,11 @@ object VerificationSeasonSamplesSpec {
       activities: List[String] => activities.nonEmpty
     }
 
-    val activitiesVerification = Verification.traverse(new ListVerification[String](nonEmptyActivityVerification), atLeastOneActivityVerification)
+    val activitiesVerification = Verification.all(new ListVerification[String](nonEmptyActivityVerification), atLeastOneActivityVerification)
 
     val optionsVerification = new ListVerification[SeasonOption](SeasonOption.seasonOptionVerification)
 
-    val seasonVerification = Verification.traverse(
+    val seasonVerification = Verification.all(
       Period.periodVerification.from((x: Season) => x.period, "period"),
       activitiesVerification.from((x: Season) => x.activities, "activities"),
       optionsVerification.from((x: Season) => x.options, "options")
@@ -154,7 +154,7 @@ object VerificationSeasonSamplesSpec {
       name: String => name.nonEmpty
     }
 
-    val seasonOptionVerification = Verification.traverse(nameVerification.from((x: SeasonOption) => x.name, "name"))
+    val seasonOptionVerification = Verification.all(nameVerification.from((x: SeasonOption) => x.name, "name"))
   }
 
   val atLeastOneEmptyActivityGen = for {

--- a/src/test/scala/definiti/scalamodel/NominalSpec.scala
+++ b/src/test/scala/definiti/scalamodel/NominalSpec.scala
@@ -77,6 +77,7 @@ object NominalSpec {
   val packageAliasType: Root = Root(
     Package(
       "tst",
+      Seq.empty,
       ObjectDef(
         name = "AliasString",
         body = Seq(

--- a/src/test/scala/definiti/scalamodel/NominalSpec.scala
+++ b/src/test/scala/definiti/scalamodel/NominalSpec.scala
@@ -1,6 +1,5 @@
 package definiti.scalamodel
 
-import definiti.core.ValidValue
 import definiti.scalamodel.ScalaAST._
 import definiti.scalamodel.helpers.EndToEndSpec
 
@@ -8,39 +7,33 @@ class NominalSpec extends EndToEndSpec {
   import NominalSpec._
 
   "The generator" should "generate a valid scala AST for a valid defined type" in {
-    val expected = ValidValue(definedType)
     val output = processFile("nominal.definedType")
-    output should be(expected)
+    output should beValidRoot(definedType)
   }
 
   it should "generate a valid scala AST for a valid alias type" in {
-    val expected = ValidValue(aliasType)
     val output = processFile("nominal.aliasType")
-    output should be(expected)
+    output should beValidRoot(aliasType)
   }
 
   it should "generate a valid scala AST for a valid verification" in {
-    val expected = ValidValue(verification)
     val output = processFile("nominal.verification")
-    output should be(expected)
+    output should beValidRoot(verification)
   }
 
   it should "generate a valid scala AST for a valid named function" in {
-    val expected = ValidValue(namedFunction)
     val output = processFile("nominal.namedFunction")
-    output should be(expected)
+    output should beValidRoot(namedFunction)
   }
 
   it should "generate nothing from an extended context" in {
-    val expected = ValidValue(extendedContext)
     val output = processFile("nominal.extendedContext")
-    output should be(expected)
+    output should beValidRoot(extendedContext)
   }
 
   it should "generate a valid scala AST for a valid alias type in a package" in {
-    val expected = ValidValue(packageAliasType)
     val output = processFile("nominal.package")
-    output should be(expected)
+    output should beValidRoot(packageAliasType)
   }
 }
 

--- a/src/test/scala/definiti/scalamodel/PlayJsonSpec.scala
+++ b/src/test/scala/definiti/scalamodel/PlayJsonSpec.scala
@@ -36,9 +36,10 @@ object PlayJsonSpec {
     Root(
       Package(
         "my",
+        Seq.empty,
         CaseClassDef("MyFirstType", Parameter("myAttribute", "String")),
         firstDefinedTypeObject(validation),
-        CaseClassDef("MySecondType", Parameter("myFirstAttribute", "BigDecimal"), Parameter("mySecondAttribute", "my.MyFirstType")),
+        CaseClassDef("MySecondType", Parameter("myFirstAttribute", "BigDecimal"), Parameter("mySecondAttribute", "MyFirstType")),
         secondDefinedTypeObject(validation)
       )
     )
@@ -94,10 +95,10 @@ object PlayJsonSpec {
       name = "MySecondType",
       body = Seq(
         attributeVerification("myFirstAttribute", "BigDecimal"),
-        attributeVerificationDefinedType("mySecondAttribute", "my.MyFirstType"),
+        attributeVerificationDefinedType("mySecondAttribute", "MyFirstType"),
         typeVerifications("MySecondType"),
         allVerifications("MySecondType", "myFirstAttribute", "mySecondAttribute"),
-        applyCheck("MySecondType", "myFirstAttribute" -> "BigDecimal", "mySecondAttribute" -> "my.MyFirstType")
+        applyCheck("MySecondType", "myFirstAttribute" -> "BigDecimal", "mySecondAttribute" -> "MyFirstType")
       ) ++ secondDefinedTypeJson(validation)
     )
   }

--- a/src/test/scala/definiti/scalamodel/SpecificSpec.scala
+++ b/src/test/scala/definiti/scalamodel/SpecificSpec.scala
@@ -65,13 +65,7 @@ object SpecificSpec {
           ClassVal(
             name = "RequiredStringVerifications",
             typ = "Verification[String]",
-            body = Seq(
-              CallMethod(
-                target = SimpleExpression("Verification"),
-                name = "traverse",
-                arguments = Seq(CallFunction("my.IsRequired"))
-              )
-            )
+            body = Seq(CallFunction("my.IsRequired"))
           ),
           aliasApplyCheck("RequiredString", "String")
         )

--- a/src/test/scala/definiti/scalamodel/SpecificSpec.scala
+++ b/src/test/scala/definiti/scalamodel/SpecificSpec.scala
@@ -22,6 +22,7 @@ object SpecificSpec {
   val numberToBigDecimalResult: Root = Root(
     Package(
       "numbers",
+      Seq.empty,
       Def1(
         name = "twice",
         typ = "BigDecimal",
@@ -48,12 +49,13 @@ object SpecificSpec {
   val attributeAsAliasType: Root = Root(
     Package(
       "my",
+      Seq.empty,
       verificationObject("IsRequired", "String", "This string is required", CallFunction("StringExtension.nonEmpty", SimpleExpression("string")), "string"),
       CaseClassDef("MyType", Parameter("attribute", "String")),
       ObjectDef(
         name = "MyType",
         body = Seq(
-          attributeVerificationAliasType("attribute", "my.RequiredString", "String"),
+          attributeVerificationAliasType("attribute", "RequiredString", "String"),
           typeVerifications("MyType"),
           allVerifications("MyType", "attribute"),
           applyCheck("MyType", "attribute" -> "String")
@@ -65,7 +67,7 @@ object SpecificSpec {
           ClassVal(
             name = "RequiredStringVerifications",
             typ = "Verification[String]",
-            body = Seq(CallFunction("my.IsRequired"))
+            body = Seq(CallFunction("IsRequired"))
           ),
           aliasApplyCheck("RequiredString", "String")
         )

--- a/src/test/scala/definiti/scalamodel/SprayJsonSpec.scala
+++ b/src/test/scala/definiti/scalamodel/SprayJsonSpec.scala
@@ -1,6 +1,5 @@
 package definiti.scalamodel
 
-import definiti.core.ValidValue
 import definiti.scalamodel.ScalaAST._
 import definiti.scalamodel.helpers.{ConfigurationMock, EndToEndSpec}
 
@@ -8,15 +7,15 @@ class SprayJsonSpec extends EndToEndSpec {
   import SprayJsonSpec._
 
   "The generator" should "generate the simple json of all defined type when no validation" in {
-    val expected = ValidValue(definedType(JsonValidation.none))
+    val expected = definedType(JsonValidation.none)
     val output = processFile("json.definedType", configuration(JsonValidation.none))
-    output should be(expected)
+    output should beValidRoot(expected)
   }
 
   it should "generate the json of all defined type with flat validation" in {
-    val expected = ValidValue(definedType(JsonValidation.flat))
+    val expected = definedType(JsonValidation.flat)
     val output = processFile("json.definedType", configuration(JsonValidation.flat))
-    output should be(expected)
+    output should beValidRoot(expected)
   }
 }
 

--- a/src/test/scala/definiti/scalamodel/SprayJsonSpec.scala
+++ b/src/test/scala/definiti/scalamodel/SprayJsonSpec.scala
@@ -35,9 +35,10 @@ object SprayJsonSpec {
     Root(
       Package(
         "my",
+        Seq.empty,
         CaseClassDef("MyFirstType", Parameter("myAttribute", "String")),
         firstDefinedTypeObject(validation),
-        CaseClassDef("MySecondType", Parameter("myFirstAttribute", "BigDecimal"), Parameter("mySecondAttribute", "my.MyFirstType")),
+        CaseClassDef("MySecondType", Parameter("myFirstAttribute", "BigDecimal"), Parameter("mySecondAttribute", "MyFirstType")),
         secondDefinedTypeObject(validation)
       )
     )
@@ -96,10 +97,10 @@ object SprayJsonSpec {
       name = "MySecondType",
       body = Seq(
         attributeVerification("myFirstAttribute", "BigDecimal"),
-        attributeVerificationDefinedType("mySecondAttribute", "my.MyFirstType"),
+        attributeVerificationDefinedType("mySecondAttribute", "MyFirstType"),
         typeVerifications("MySecondType"),
         allVerifications("MySecondType", "myFirstAttribute", "mySecondAttribute"),
-        applyCheck("MySecondType", "myFirstAttribute" -> "BigDecimal", "mySecondAttribute" -> "my.MyFirstType")
+        applyCheck("MySecondType", "myFirstAttribute" -> "BigDecimal", "mySecondAttribute" -> "MyFirstType")
       ) ++ secondDefinedTypeJson(validation)
     )
   }

--- a/src/test/scala/definiti/scalamodel/helpers/ASTMatcher.scala
+++ b/src/test/scala/definiti/scalamodel/helpers/ASTMatcher.scala
@@ -55,7 +55,7 @@ trait ASTMatcher {
     }
 
     private def printPackageElement(packageElement: PackageElement, indent: String): String = packageElement match {
-      case Package(name, elements) =>
+      case Package(name, _, elements) =>
         s"""package ${name} {
            |${elements.map(printPackageElement(_, ScalaCodeGenerator.inc(indent)))}
            |}


### PR DESCRIPTION
The generated code is quite complex to understand and have lot of unnecessary code.
To increase understandability, we refactor a little the generated code.

The generated code always used the full name of types, verifications and functions.
It became complex to read it.
To increase the readability, we use `Import` statements instead.

This commit does the following:

* Add a `Verification.none` instead of an empty `apply` (explicitness)
* Rename `Verification.traverse` to `Verification.all` (more accurate in terms of behavior)
* Instead of always calling `Verification.all`, use `Verification.none` or direct verification reference when possible
* Same for `ListVerification` and `OptionVerification`
* Correct tests to be in sync with optimizations
* Extract the list of types to create the `Import` statements
* Use only the last part of types, verification and functions instead of the full name
* Add `ScalaAST.Blank` to create blank lines
* Correct tests to remove package names from types, verifications and functions