### PR TITLE
Correct the deep validation of json parsers

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -11,10 +11,10 @@ definiti {
 
     json {
       # play, spray, none
-      format = "play"
+      format = "none"
 
-      # flat, none
-      validation = "flat"
+      # true, false
+      validation = false
     }
   }
 }

--- a/src/main/resources/samples/src2/person.def
+++ b/src/main/resources/samples/src2/person.def
@@ -24,6 +24,10 @@ type Person {
 type Identity {
   firstName: RequiredNoun
   lastName: RequiredNoun
+  contact: Contact
+}
+
+type Contact {
   email: RequiredString
   phones: List[Phone]
 }

--- a/src/main/scala/definiti/scalamodel/ScalaAST.scala
+++ b/src/main/scala/definiti/scalamodel/ScalaAST.scala
@@ -111,8 +111,16 @@ object ScalaAST {
   case class CallFunction(target: Expression, arguments: Seq[Expression]) extends Expression with Unambiguous
 
   object CallFunction {
+    def apply(target: String): CallFunction = {
+      new CallFunction(SimpleExpression(target), Seq.empty)
+    }
+
     def apply(target: String, arguments: Expression*): CallFunction = {
       new CallFunction(SimpleExpression(target), arguments)
+    }
+
+    def apply(target: String, arguments: String*)(implicit dummyImplicit: DummyImplicit): CallFunction = {
+      new CallFunction(SimpleExpression(target), arguments.map(SimpleExpression))
     }
   }
 
@@ -186,7 +194,7 @@ object ScalaAST {
     def apply(statement: Option[Statement]): StatementsGroup = new StatementsGroup(statement.toSeq)
   }
 
-  case class Val(name: String, value: Expression, isLazy: Boolean = false) extends Statement
+  case class Val(name: String, value: Expression, isLazy: Boolean = false, isImplicit: Boolean = false) extends Statement
 
   case class TraitDef(name: String, body: Seq[Statement], isSealed: Boolean = false) extends Statement
 

--- a/src/main/scala/definiti/scalamodel/builder/TypeBuilder.scala
+++ b/src/main/scala/definiti/scalamodel/builder/TypeBuilder.scala
@@ -69,13 +69,6 @@ trait TypeBuilder {
     }
   }
 
-  def generateTag(aliasType: AliasType): ScalaAST.Statement = {
-    ScalaAST.StatementsGroup(
-      ScalaAST.TraitDef(s"${aliasType.name}Tag", Seq.empty, isSealed = true),
-      ScalaAST.TypeDef(aliasType.name, s"${generateType(aliasType.alias)} @@ ${aliasType.name}Tag")
-    )
-  }
-
   def generateGenericTypeDefinition(definedType: DefinedType): String = {
     if (definedType.genericTypes.nonEmpty) {
       definedType.genericTypes.mkString("[", ",", "]")
@@ -118,6 +111,14 @@ trait TypeBuilder {
       genericTypes.mkString("[", ",", "]")
     } else {
       ""
+    }
+  }
+
+  def isNative(typeReference: TypeReference): Boolean = {
+    library.types.get(typeReference.typeName).exists {
+      case _: NativeClassDefinition => true
+      case alias: AliasType => isNative(alias.alias)
+      case _ => false
     }
   }
 

--- a/src/test/scala/definiti/scalamodel/helpers/ConfigurationMock.scala
+++ b/src/test/scala/definiti/scalamodel/helpers/ConfigurationMock.scala
@@ -2,12 +2,12 @@ package definiti.scalamodel.helpers
 
 import java.nio.file.{Path, Paths}
 
-import definiti.scalamodel.{Configuration, JsonConfiguration, JsonFormat, JsonValidation}
+import definiti.scalamodel.{Configuration, JsonConfiguration, JsonFormat}
 
 case class ConfigurationMock(
   destination: Path = Paths.get(""),
   json: JsonConfiguration = JsonConfiguration(
     format = JsonFormat.none,
-    validation = JsonValidation.none
+    validation = false
   )
 ) extends Configuration


### PR DESCRIPTION
When testing json parsers in real use cases, we encountered a strange behavior.
When there was an error from validations in nested type,
only the error into the nested type were returned.

This commit resolves this issue by forcing the building of the type
without validations and validate the whole aggregate at last.

In case of Json with validation, json builders now have two parsers:
an implicit one and a raw one.
The raw one is used when the type is used in another one.
We import the nested type raw parser as implicit to build the main raw parser.
It is only for external uses that the implicit parser (with validation) will be used.

This commit does the following:

* Change the json configuration, to have validations as a boolean instead of an enum
* Json builders now use `ScalaModelBuilder` so we change their design
* Json builders have two parsers: a raw one and an implicit one (see above)
* Update `ScalaAST.Val` so we can have `implicit` local `val`
* Update the body generation so when there is several statements, we use braces
* Remove unused `TypeBuilder.generateTag` (old strategy removed during 0.2.0 development)
* Change sample `src2/person.def` to have a nested type